### PR TITLE
Update the silta definitions for silta1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  silta: silta/silta@0.1
+  silta: silta/silta@1
 
 executors:
   cicd82:

--- a/silta/nginx.Dockerfile
+++ b/silta/nginx.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for the Nginx container.
-FROM wunderio/silta-nginx:latest
+FROM wunderio/silta-nginx:1.17-v1
 
 COPY . /app/web


### PR DESCRIPTION
This PR updates the silta setup according to the instructions posted at https://github.com/wunderio/silta/releases/tag/2023-10-03

I have changed the nginx dockerfile definition only, since we are using specially defined images for all other dockerfils.