### PR TITLE
Sync drupal token expiration time, and session validity in frontend

### DIFF
--- a/drupal/recipes/wunder_next_setup/config/simple_oauth.settings.yml
+++ b/drupal/recipes/wunder_next_setup/config/simple_oauth.settings.yml
@@ -1,5 +1,5 @@
-access_token_expiration: 300
-authorization_code_expiration: 300
+access_token_expiration: 432000
+authorization_code_expiration: 432000
 refresh_token_expiration: 1209600
 token_cron_batch_size: 0
 public_key: ../oauth/public.key

--- a/next/pages/api/auth/[...nextauth].ts
+++ b/next/pages/api/auth/[...nextauth].ts
@@ -9,6 +9,13 @@ export const authOptions: NextAuthOptions = {
   pages: {
     signIn: "/auth/login",
   },
+  // We set the maxAge of the session to the same value as the token expiration
+  // with the idea that the user will be logged out automatically when the token
+  // is no longer valid.
+  // The token expiration is set to 5 days in Drupal.
+  session: {
+    maxAge: 5 * 24 * 60 * 60, // 5 days
+  },
   providers: [
     CredentialsProvider({
       name: "Drupal",


### PR DESCRIPTION
Before, the token was set to expire each 300 seconds, and the session in frontend was using the default value in next-auth, which is 30 days. 

This meant that it was likely to have a situation where the user was logged into the frontend, but the site used an expired token when doing calls to the backend.

both are now set to 5 days.

I think we should still investigate how to improve how the session is handled (for example checking it periodically and logging the user out if the token is expired and cannot be renewed etc), but this should be an improvement already.