### PR TITLE
Use silta v1 major tags for docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   cicd82:
     docker:
-      - image: wunderio/silta-cicd:circleci-php8.2-node18-composer2-v0.2.2
+      - image: wunderio/silta-cicd:circleci-php8.2-node18-composer2-v1
     resource_class: small
 
 commands:
@@ -134,7 +134,7 @@ commands:
             fi
 
             project_name=next-drupal-starterkit
-            
+
             drupal_domain=$drupal_release_name.$project_name.$CLUSTER_DOMAIN
             next_domain=$next_release_name.$project_name.$CLUSTER_DOMAIN
             drupal_client_id=drupal-client-id
@@ -298,9 +298,9 @@ workflows:
                 path: next
           image_build_steps:
             - silta/build-docker-image:
-                dockerfile: 'silta/node.Dockerfile'
-                path: './next'
-                identifier: 'node'
+                dockerfile: "silta/node.Dockerfile"
+                path: "./next"
+                identifier: "node"
                 docker-hash-prefix: v1
           filters:
             branches:
@@ -308,7 +308,7 @@ workflows:
                 - main
                 - production
                 - /dependabot\/.*/
-          requires: [ Drupal build & deploy ]
+          requires: [Drupal build & deploy]
 
       - silta/frontend-build-deploy:
           # Extend the build-deploy configuration for the main environment.
@@ -328,7 +328,7 @@ workflows:
           filters:
             branches:
               only: main
-          requires: [ Drupal build & deploy main ]
+          requires: [Drupal build & deploy main]
 
       - silta/frontend-build-deploy:
           # Extend the build-deploy configuration for the production environment.
@@ -348,7 +348,7 @@ workflows:
           filters:
             branches:
               only: production
-          requires: [ Drupal build & deploy production ]
+          requires: [Drupal build & deploy production]
 
       # Special rules for the dependabot branches.
       - silta/frontend-build-deploy:

--- a/silta/node.Dockerfile
+++ b/silta/node.Dockerfile
@@ -1,4 +1,4 @@
-FROM wunderio/silta-node:18-alpine-v0.1.2
+FROM wunderio/silta-node:18-alpine-v1
 
 COPY . /app
 

--- a/silta/php.Dockerfile
+++ b/silta/php.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for the PHP container.
-FROM wunderio/silta-php-fpm:8.2-fpm-v1.0.0
+FROM wunderio/silta-php-fpm:8.2-fpm-v1
 
 COPY --chown=www-data:www-data . /app

--- a/silta/shell.Dockerfile
+++ b/silta/shell.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for the Shell container.
-FROM wunderio/silta-php-shell:php8.2-v1.0.0
+FROM wunderio/silta-php-shell:php8.2-v1
 
 COPY --chown=www-data:www-data . /app


### PR DESCRIPTION
This means the Docker images would be updated with the latest fixes. Related to Jānis' comment in slack [here](https://wunder.slack.com/archives/C8UN6AG9W/p1696507963658529?thread_ts=1696500393.268959&cid=C8UN6AG9W)