### PR TITLE
Add script that runs all the commands required to start the project.

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# List of commands to run
+commands=(
+  "lando rebuild -y"
+  "lando composer install"
+  "lando generate-oauth-keys"
+  "lando drush si minimal -y"
+  "lando install-recipe wunder_next_setup"
+  "lando drush wunder_next:setup-user-and-consumer"
+  "lando drush eshd -y"
+  "lando drush eshs"
+  "lando npm i"
+  "lando npm run build"
+  "(lando npm run start&)"
+  "lando drush en wunder_democontent -y"
+  "lando drush mim --group=demo_content --execute-dependencies"
+  "lando drush uli"
+)
+
+last_successful_command=0
+
+status_file=".last_successful_command"
+
+# Run the commands
+run_commands() {
+  for ((i = $last_successful_command; i < ${#commands[@]}; ++i)); do
+    command="${commands[$i]}"
+    echo "Running command: $command"
+    last_successful_command=$i
+    echo $last_successful_command > $status_file
+    if eval "$command"; then
+      echo "Command successful"
+    else
+      echo "Command failed"
+      exit 1
+    fi
+  done
+
+  # All commands were successful, remove the status file
+  rm -f "$status_file"
+  echo "All commands completed successfully"
+}
+
+# Check if there's a status file indicating the last successful command
+if [ -f "$status_file" ]; then
+  read -r last_successful_command < "$status_file"
+fi
+
+run_commands


### PR DESCRIPTION
## Link to ticket:

No ticket as I was just doing some ad hoc scripting

## Link to feature environment:

No feature environment needed, this is local development setup  command

## Changes proposed in this PR:

This PR adds a script named start.sh which is able to run all the commends from the "mega command" and is also keeping track of the status so if any step fails the consecutive runs will continue from the last failed command instead of running all commands from the beginning.

## How to test:

1. Run ./start.sh in project root
2. Interrupt some command execution along the way (e.g. with CTRL-C)
3. Rerun the command and verify it continues from the step you interrupted it
4. Let it run to the end and verify you have fully working environment setup

