### PR TITLE
Add an .eslintignore file to exclude some directories from eslint.

### DIFF
--- a/next/.eslintignore
+++ b/next/.eslintignore
@@ -1,0 +1,3 @@
+storybook-static
+node_modules
+.next


### PR DESCRIPTION
This PR adds a `.eslintignore` file to tell eslint to not look into node_modules, .next, etc.

### Before this change

`lando npm run lint`  would hang (or, take forever)

### After this change

`lando npm run lint` should take a reasonable time.