### PR TITLE
NEX-118: Improve handling of expired login sessions

### DIFF
--- a/next/components/header/user-menu.tsx
+++ b/next/components/header/user-menu.tsx
@@ -72,7 +72,7 @@ export function UserMenu() {
       <span className="sr-only">{t("user-menu")}</span>
       <button type="button" className="hover:underline" onClick={toggle}>
         <span className="sr-only capitalize sm:not-sr-only sm:mr-2 sm:inline">
-          {t("account")}
+          {t("user-menu-account")}
         </span>
         <AccountIcon className="inline-block h-6 w-6" />
       </button>

--- a/next/lib/auth/redirect-expired-login.ts
+++ b/next/lib/auth/redirect-expired-login.ts
@@ -1,0 +1,15 @@
+import type { Redirect } from "next";
+
+export function redirectExpiredSessionToLoginPage(
+  locale: string,
+  callbackUrl: string,
+) {
+  const redirect: Redirect = {
+    destination: `/${locale}/auth/login?logout=true&callbackUrl=${encodeURIComponent(
+      callbackUrl,
+    )}`,
+    permanent: false,
+  };
+
+  return { redirect };
+}

--- a/next/pages/api/auth/[...nextauth].ts
+++ b/next/pages/api/auth/[...nextauth].ts
@@ -52,7 +52,7 @@ export const authOptions: NextAuthOptions = {
     }),
   ],
   callbacks: {
-    jwt: async function ({ token, user, account, trigger }) {
+    async jwt({ token, user, account, trigger }) {
       if (account && user) {
         token.accessToken = user.access_token;
         token.accessTokenExpires = Date.now() + user.expires_in * 1000;

--- a/next/pages/auth/login.tsx
+++ b/next/pages/auth/login.tsx
@@ -22,19 +22,24 @@ type Inputs = {
 };
 
 export default function LogIn() {
-  const { callbackUrl, error } = useRouter().query;
+  const {
+    locale,
+    query: {
+      callbackUrl = "",
+      error = "",
+      enteredEmail = "",
+      newPasswordRequested = false,
+      passwordJustUpdated = false,
+    },
+  } = useRouter();
   const { t } = useTranslation();
+
   const {
     register,
     formState: { errors },
     handleSubmit,
   } = useForm<Inputs>();
 
-  const router = useRouter();
-  const isPasswordUpdated = Boolean(router.query.passwordJustUpdated) || false;
-  const isPasswordRequested =
-    Boolean(router.query.newPasswordRequested) || false;
-  const enteredEmail = router.query.enteredEmail || "";
   const [isSubmitting, setIsSubmitting] = useState(false);
   const onSubmit = async ({ username, password }: Inputs) => {
     setIsSubmitting(true);
@@ -46,19 +51,18 @@ export default function LogIn() {
     setIsSubmitting(false);
   };
 
-  const resetPasswordBackendUrl =
-    env.NEXT_PUBLIC_DRUPAL_BASE_URL + "/" + router.locale + "/user/password";
+  const resetPasswordBackendUrl = `${env.NEXT_PUBLIC_DRUPAL_BASE_URL}/${locale}/user/password`;
 
   return (
     <>
       <Meta title={t("log-in")} metatags={[]} />
       <div className="max-w-md pb-16 pt-8 font-work">
-        {isPasswordUpdated && (
+        {passwordJustUpdated && (
           <StatusMessage level="success" className="mb-8">
             {t("password-updated-login-below")}
           </StatusMessage>
         )}
-        {isPasswordRequested && (
+        {newPasswordRequested && (
           <StatusMessage level="info" className="mb-8">
             {t("password-reset-check-your-email", { email: enteredEmail })}
           </StatusMessage>

--- a/next/pages/auth/login.tsx
+++ b/next/pages/auth/login.tsx
@@ -1,7 +1,7 @@
 import type { GetStaticPropsContext } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { signIn } from "next-auth/react";
+import { signIn, signOut } from "next-auth/react";
 import { useTranslation } from "next-i18next";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
@@ -9,6 +9,7 @@ import { useForm } from "react-hook-form";
 import { ErrorRequired } from "@/components/error-required";
 import { Meta } from "@/components/meta";
 import { getCommonPageProps } from "@/lib/get-common-page-props";
+import { useEffectOnce } from "@/lib/hooks/use-effect-once";
 
 import { env } from "@/env";
 import { Button } from "@/ui/button";
@@ -30,6 +31,7 @@ export default function LogIn() {
       enteredEmail = "",
       newPasswordRequested = false,
       passwordJustUpdated = false,
+      logout = false,
     },
   } = useRouter();
   const { t } = useTranslation();
@@ -53,6 +55,10 @@ export default function LogIn() {
   };
 
   const resetPasswordBackendUrl = `${env.NEXT_PUBLIC_DRUPAL_BASE_URL}/${locale}/user/password`;
+
+  useEffectOnce(() => {
+    if (logout) void signOut();
+  });
 
   return (
     <>

--- a/next/pages/auth/login.tsx
+++ b/next/pages/auth/login.tsx
@@ -74,6 +74,11 @@ export default function LogIn() {
             {t("password-reset-check-your-email", { email: enteredEmail })}
           </StatusMessage>
         )}
+        {logout && (
+          <StatusMessage level="info" className="mb-8">
+            {t("your-session-has-expired")}
+          </StatusMessage>
+        )}
         {error && (
           <StatusMessage level="error" className="mb-8">
             {t("login-error-check-username-password")}

--- a/next/pages/auth/login.tsx
+++ b/next/pages/auth/login.tsx
@@ -46,7 +46,8 @@ export default function LogIn() {
     await signIn("credentials", {
       username,
       password,
-      callbackUrl: typeof callbackUrl === "string" ? callbackUrl : "/",
+      callbackUrl:
+        typeof callbackUrl === "string" ? callbackUrl : `/${locale}}`,
     });
     setIsSubmitting(false);
   };

--- a/next/pages/dashboard/index.tsx
+++ b/next/pages/dashboard/index.tsx
@@ -84,19 +84,22 @@ export const getServerSideProps: GetServerSideProps<
     submissions: WebformSubmissionsListItem[];
   }
 > = async (context) => {
+  const { locale, resolvedUrl } = context;
   const session = await getServerSession(context.req, context.res, authOptions);
 
   if (!session) {
     return {
       redirect: {
-        destination: "/",
+        destination: `/${locale}/auth/login?callbackUrl=${encodeURIComponent(
+          resolvedUrl,
+        )}`,
         permanent: false,
       },
     };
   }
 
   const url = drupal.buildUrl(
-    `/${context.locale}/rest/my-webform-submissions?_format=json`,
+    `/${locale}/rest/my-webform-submissions?_format=json`,
   );
 
   const result = await drupal.fetch(url.toString(), {

--- a/next/pages/dashboard/index.tsx
+++ b/next/pages/dashboard/index.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "next-i18next";
 
 import { HeadingPage } from "@/components/heading--page";
 import { Meta } from "@/components/meta";
+import { redirectExpiredSessionToLoginPage } from "@/lib/auth/redirect-expired-login";
 import { drupal } from "@/lib/drupal/drupal-client";
 import {
   CommonPageProps,
@@ -88,14 +89,7 @@ export const getServerSideProps: GetServerSideProps<
   const session = await getServerSession(context.req, context.res, authOptions);
 
   if (!session) {
-    return {
-      redirect: {
-        destination: `/${locale}/auth/login?logout=true&callbackUrl=${encodeURIComponent(
-          resolvedUrl,
-        )}`,
-        permanent: false,
-      },
-    };
+    return redirectExpiredSessionToLoginPage(locale, resolvedUrl);
   }
 
   const url = drupal.buildUrl(

--- a/next/pages/dashboard/index.tsx
+++ b/next/pages/dashboard/index.tsx
@@ -90,7 +90,7 @@ export const getServerSideProps: GetServerSideProps<
   if (!session) {
     return {
       redirect: {
-        destination: `/${locale}/auth/login?callbackUrl=${encodeURIComponent(
+        destination: `/${locale}/auth/login?logout=true&callbackUrl=${encodeURIComponent(
           resolvedUrl,
         )}`,
         permanent: false,

--- a/next/pages/dashboard/webforms/[webformName]/[webformSubmissionUuid].tsx
+++ b/next/pages/dashboard/webforms/[webformName]/[webformSubmissionUuid].tsx
@@ -57,19 +57,22 @@ export const getServerSideProps: GetServerSideProps<
     submission: WebformSubmission;
   }
 > = async (context) => {
+  const { locale, params, resolvedUrl } = context;
   const session = await getServerSession(context.req, context.res, authOptions);
 
   if (!session) {
     return {
       redirect: {
-        destination: "/",
+        destination: `/${locale}/auth/login?callbackUrl=${encodeURIComponent(
+          resolvedUrl,
+        )}`,
         permanent: false,
       },
     };
   }
 
   const url = drupal.buildUrl(
-    `/${context.locale}/webform_rest/${context.params.webformName}/complete_submission/${context.params.webformSubmissionUuid}`,
+    `/${locale}/webform_rest/${params.webformName}/complete_submission/${params.webformSubmissionUuid}`,
   );
 
   const result = await drupal.fetch(url.toString(), {

--- a/next/pages/dashboard/webforms/[webformName]/[webformSubmissionUuid].tsx
+++ b/next/pages/dashboard/webforms/[webformName]/[webformSubmissionUuid].tsx
@@ -63,7 +63,7 @@ export const getServerSideProps: GetServerSideProps<
   if (!session) {
     return {
       redirect: {
-        destination: `/${locale}/auth/login?callbackUrl=${encodeURIComponent(
+        destination: `/${locale}/auth/login?logout=true&callbackUrl=${encodeURIComponent(
           resolvedUrl,
         )}`,
         permanent: false,

--- a/next/pages/dashboard/webforms/[webformName]/[webformSubmissionUuid].tsx
+++ b/next/pages/dashboard/webforms/[webformName]/[webformSubmissionUuid].tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "next-i18next";
 
 import { HeadingPage } from "@/components/heading--page";
 import { Meta } from "@/components/meta";
+import { redirectExpiredSessionToLoginPage } from "@/lib/auth/redirect-expired-login";
 import { drupal } from "@/lib/drupal/drupal-client";
 import {
   CommonPageProps,
@@ -61,14 +62,7 @@ export const getServerSideProps: GetServerSideProps<
   const session = await getServerSession(context.req, context.res, authOptions);
 
   if (!session) {
-    return {
-      redirect: {
-        destination: `/${locale}/auth/login?logout=true&callbackUrl=${encodeURIComponent(
-          resolvedUrl,
-        )}`,
-        permanent: false,
-      },
-    };
+    return redirectExpiredSessionToLoginPage(locale, resolvedUrl);
   }
 
   const url = drupal.buildUrl(

--- a/next/public/locales/en/common.json
+++ b/next/public/locales/en/common.json
@@ -79,5 +79,6 @@
   "password-updated-login-below": "Your password has been updated. Please log in below.",
   "password-reset-check-your-email": "If {{email}} was associated with a actual account, check your email for a link to reset your password.",
   "reset-your-password": "Reset your password",
+  "your-session-has-expired": "Your session has expired. Please log in again to continue.",
   "field-is-required": "The {{field}} field is required."
 }

--- a/next/public/locales/fi/common.json
+++ b/next/public/locales/fi/common.json
@@ -79,5 +79,6 @@
   "password-reset-check-your-email": "Jos {{email}} oli liitetty oikeaan tiliin, tarkista sähköpostistasi linkki salasanan vaihtamiseen.",
   "password-updated-login-below": "Salasanasi on päivitetty. Voit kirjautua sisään alla olevalla lomakkeella.",
   "reset-your-password": "Nollaa salasanasi",
+  "your-session-has-expired": "Istuntosi on vanhentunut. Kirjaudu sisään jatkaaksesi.",
   "field-is-required": "'{{field}}' kenttä on pakollinen"
 }

--- a/next/public/locales/sv/common.json
+++ b/next/public/locales/sv/common.json
@@ -79,5 +79,6 @@
   "password-updated-login-below": "Ditt lösenord har uppdaterats. Du kan logga in med formuläret nedan.",
   "password-reset-check-your-email": "Om {{email}} var associerad med ett faktiskt konto, kontrollera din e-post efter en länk för att återställa ditt lösenord.",
   "reset-your-password": "Återställ ditt lösenord",
+  "your-session-has-expired": "Din session har gått ut. Logga in igen för att fortsätta.",
   "field-is-required": "{{field}} är obligatoriskt."
 }


### PR DESCRIPTION
## Link to ticket:

https://wunder.atlassian.net/browse/FAIS-44

## Changes proposed in this PR:

Previously, if a logged in user's session expired, it was problematic because the frontend didn't "react" to it properly. If a logged-in user's session expired and they tried to access a protected route, they would be kicked to the frontpage (always in English), but the UI in the header would still show their username and give no indication that they aren't actually logged in anymore. The only way to resolve it was for the user to guess that logging out and back in would solve the problem.

This PR improves the situation like so:

If a logged-in user with an expired access token tries to visit `/dashboard`, which is a protected route, they are instead redirected to the `/auth/login` page in the correct language. Additionally, a new query param `logout=true` is added, which the login page uses to log the user out after the page has loaded on the client. This means it's very clear for the user that they have been logged out and must login again.

Note, rather than logout using the "logout" query param, it would be nice if we could simply log the user out in the server-side instead somehow. However, it seems [that's not possible](https://github.com/nextauthjs/next-auth/discussions/5334), so we log the user out clientside using the query param instead.

## Changes NOT proposed in this PR:

It would be nice to also ensure the sessions are refreshed at appropriate intervals using the refresh token, to minimise the chance of this happening in the first place. This PR doesn't address that, however - I'll look into that next and leave the ticket open in Jira for now.

## How to test:

1. Watch the helpful video I just sent you on slack!
2. To test locally, it's useful to change the maxAge to e.g. `10` (seconds) [here](https://github.com/wunderio/next-drupal-starterkit/blob/main/next/pages/api/auth/%5B...nextauth%5D.ts#L17). That way you can login and see what happens without waiting too long for the token to expire.
3. Be sure to test different languages too to ensure the redirects work as expected.
