### PR TITLE
NEX-125: Update MenuItem types

### DIFF
--- a/next/lib/zod/menu.ts
+++ b/next/lib/zod/menu.ts
@@ -3,9 +3,13 @@ import { z } from "zod";
 import { DrupalMenuLinkContentWithLangcode } from "@/types";
 
 export const MenuItemOptionsSchema = z.object({
-  attributes: z.object({
-    icon: z.string(),
-  }),
+  external: z.boolean().optional(),
+  attributes: z
+    .object({
+      icon: z.string(),
+    })
+    .nullable()
+    .optional(),
 });
 
 const BaseMenuItemSchema = z.object({


### PR DESCRIPTION
- Set "attributes" property as optional -> without this change, a menu item that does not have "attributes" set will break the site.
- Add "external" property to MenuItem schema

Example menu item with both `attributes` and `external`:

```
{
    "type": "menu_link_content--menu_link_content",
    "id": "menu_link_content:6c12ce5c-7d2b-4b5f-96ab-e993296986bb",
    "description": null,
    "enabled": true,
    "expanded": false,
    "menu_name": "main",
    "meta": {
      "entity_id": "18"
    },
    "options": {
      "attributes": {
        "icon": "twitter"
      },
      "external": true
    },
    "parent": "",
    "provider": "menu_link_content",
    "route": {
      "name": "",
      "parameters": []
    },
    "title": "Example external link",
    "url": "https://www.google.com",
    "weight": 0,
    "langcode": "en"
  }
  ```