### PR TITLE
NEX-128: Add limits for images in pixel size and megabyte size 

### DIFF
--- a/drupal/recipes/wunder_base/config/editor.editor.basic_html.yml
+++ b/drupal/recipes/wunder_base/config/editor.editor.basic_html.yml
@@ -7,7 +7,7 @@ dependencies:
   module:
     - ckeditor5
 _core:
-  default_config_hash: lZlUTSJqWaN3iU0I0fhvQVgqf4ps9fxPPC-g_9aWIRc
+  default_config_hash: FDAuwq_V_tyB_RL8utnPAjK7j9kMuiKeruaSOu7KAeA
 format: basic_html
 editor: ckeditor5
 settings:
@@ -60,7 +60,7 @@ image_upload:
   status: true
   scheme: public
   directory: inline-images
-  max_size: ''
+  max_size: '5 MB'
   max_dimensions:
-    width: 0
-    height: 0
+    width: 2500
+    height: 2500

--- a/drupal/recipes/wunder_base/config/editor.editor.full_html.yml
+++ b/drupal/recipes/wunder_base/config/editor.editor.full_html.yml
@@ -7,7 +7,7 @@ dependencies:
   module:
     - ckeditor5
 _core:
-  default_config_hash: qtbIKnf_F-jhwZ-rl2ajm3BfFNPj8INYFVd2_5k6UFA
+  default_config_hash: ryQIG1PylLKVV2cpsEYd75RWYKAvkUs4w3yrwg7AjNM
 format: full_html
 editor: ckeditor5
 settings:
@@ -35,6 +35,50 @@ settings:
       - '|'
       - sourceEditing
   plugins:
+    ckeditor5_codeBlock:
+      languages:
+        -
+          label: 'Plain text'
+          language: plaintext
+        -
+          label: C
+          language: c
+        -
+          label: 'C#'
+          language: cs
+        -
+          label: C++
+          language: cpp
+        -
+          label: CSS
+          language: css
+        -
+          label: Diff
+          language: diff
+        -
+          label: HTML
+          language: html
+        -
+          label: Java
+          language: java
+        -
+          label: JavaScript
+          language: javascript
+        -
+          label: PHP
+          language: php
+        -
+          label: Python
+          language: python
+        -
+          label: Ruby
+          language: ruby
+        -
+          label: TypeScript
+          language: typescript
+        -
+          label: XML
+          language: xml
     ckeditor5_heading:
       enabled_headings:
         - heading2
@@ -53,7 +97,7 @@ image_upload:
   status: true
   scheme: public
   directory: inline-images
-  max_size: ''
+  max_size: '5 MB'
   max_dimensions:
-    width: 0
-    height: 0
+    width: 2500
+    height: 2500

--- a/drupal/recipes/wunder_base/config/field.field.node.article.field_image.yml
+++ b/drupal/recipes/wunder_base/config/field.field.node.article.field_image.yml
@@ -6,9 +6,16 @@ dependencies:
     - field.storage.node.field_image
     - node.type.article
   module:
+    - content_translation
     - image
+third_party_settings:
+  content_translation:
+    translation_sync:
+      alt: alt
+      title: title
+      file: '0'
 _core:
-  default_config_hash: PmVL51L3A9QGbPLoeLHw5epAPszeZRasCeC3imeeDRQ
+  default_config_hash: sb1lfSeRR7VS0EPl9A17cmIye6KESnSkPdk-0p5fU4Y
 id: node.article.field_image
 field_name: field_image
 entity_type: node
@@ -24,15 +31,15 @@ settings:
   handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg'
-  max_filesize: ''
-  max_resolution: ''
+  max_filesize: '5 MB'
+  max_resolution: 2500x2500
   min_resolution: ''
   alt_field: true
   alt_field_required: true
   title_field: false
   title_field_required: false
   default_image:
-    uuid: null
+    uuid: ''
     alt: ''
     title: ''
     width: null

--- a/drupal/recipes/wunder_base/config/field.field.node.article.field_image.yml
+++ b/drupal/recipes/wunder_base/config/field.field.node.article.field_image.yml
@@ -6,14 +6,7 @@ dependencies:
     - field.storage.node.field_image
     - node.type.article
   module:
-    - content_translation
     - image
-third_party_settings:
-  content_translation:
-    translation_sync:
-      alt: alt
-      title: title
-      file: '0'
 _core:
   default_config_hash: sb1lfSeRR7VS0EPl9A17cmIye6KESnSkPdk-0p5fU4Y
 id: node.article.field_image

--- a/drupal/recipes/wunder_base/config/filter.format.basic_html.yml
+++ b/drupal/recipes/wunder_base/config/filter.format.basic_html.yml
@@ -4,8 +4,6 @@ status: true
 dependencies:
   module:
     - editor
-_core:
-  default_config_hash: RjoJPQLCAE8u1Ys_yCKubpkYlRz_Oy12a5qCVeNIHJ8
 name: 'Basic HTML'
 format: basic_html
 weight: 0
@@ -16,7 +14,7 @@ filters:
     status: true
     weight: -10
     settings:
-      allowed_html: '<br> <p> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <cite> <dl> <dt> <dd> <a hreflang href> <blockquote cite> <ul type> <ol start type> <strong> <em> <code> <li> <img src alt data-entity-uuid data-entity-type height width data-caption data-align>'
+      allowed_html: '<br> <p> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <cite> <dl> <dt> <dd> <a hreflang href> <blockquote cite> <ul type> <ol start type> <strong> <em> <code> <li> <img src alt height width data-entity-uuid data-entity-type data-caption data-align>'
       filter_html_help: false
       filter_html_nofollow: false
   filter_align:

--- a/drupal/recipes/wunder_base/config/filter.format.full_html.yml
+++ b/drupal/recipes/wunder_base/config/filter.format.full_html.yml
@@ -5,7 +5,7 @@ dependencies:
   module:
     - editor
 _core:
-  default_config_hash: WNeK5FbcY8pXgEpbD_KgRzlF1-5PL3BJXwqaBctPTqw
+  default_config_hash: dmI9xzTIK66kaJzRkLMfH3KxxmQm36eGtzjH93cZGEE
 name: 'Full HTML'
 format: full_html
 weight: 2
@@ -34,3 +34,12 @@ filters:
     status: true
     weight: 11
     settings: {  }
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: false
+    weight: -10
+    settings:
+      allowed_html: ''
+      filter_html_help: true
+      filter_html_nofollow: false

--- a/drupal/recipes/wunder_base/config/filter.format.restricted_html.yml
+++ b/drupal/recipes/wunder_base/config/filter.format.restricted_html.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 _core:
-  default_config_hash: oz6NyPDAB4HB6N9hgH2LwNVtCd-sXbMG1fbn5KsRIDI
+  default_config_hash: KiTj6Oh1Ba4Bpr4UXtqD2-a6HD4YeJ6RqjpVVn5Pe8A
 name: 'Restricted HTML'
 format: restricted_html
 weight: 1

--- a/drupal/recipes/wunder_media/config/field.field.media.image.field_media_image.yml
+++ b/drupal/recipes/wunder_media/config/field.field.media.image.field_media_image.yml
@@ -6,17 +6,10 @@ dependencies:
     - field.storage.media.field_media_image
     - media.type.image
   module:
-    - content_translation
     - image
   enforced:
     module:
       - media
-third_party_settings:
-  content_translation:
-    translation_sync:
-      alt: alt
-      title: title
-      file: '0'
 _core:
   default_config_hash: HGRX21ciyn7K-q8KMxsKHQvIB4SHT-A3bqzmNDnGKyc
 id: media.image.field_media_image

--- a/drupal/recipes/wunder_media/config/field.field.media.image.field_media_image.yml
+++ b/drupal/recipes/wunder_media/config/field.field.media.image.field_media_image.yml
@@ -1,3 +1,4 @@
+uuid: 16534b66-13b9-4fc4-9af9-bc65dd746d51
 langcode: en
 status: true
 dependencies:
@@ -5,10 +6,19 @@ dependencies:
     - field.storage.media.field_media_image
     - media.type.image
   module:
+    - content_translation
     - image
   enforced:
     module:
       - media
+third_party_settings:
+  content_translation:
+    translation_sync:
+      alt: alt
+      title: title
+      file: '0'
+_core:
+  default_config_hash: HGRX21ciyn7K-q8KMxsKHQvIB4SHT-A3bqzmNDnGKyc
 id: media.image.field_media_image
 field_name: field_media_image
 entity_type: media
@@ -24,15 +34,15 @@ settings:
   handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg'
-  max_filesize: ''
-  max_resolution: ''
+  max_filesize: '5 MB'
+  max_resolution: 2500x2500
   min_resolution: ''
   alt_field: true
   alt_field_required: true
   title_field: false
   title_field_required: false
   default_image:
-    uuid: null
+    uuid: ''
     alt: ''
     title: ''
     width: null


### PR DESCRIPTION
Too big images can crash the site, this branch limits to: 
2500 x 2500 
and  5 megabytes. 

Larger images will be resized.

This applies to: 

- image in article
- image in media item
- images added to wysiwyg fields.