### PR TITLE
NEX-134: Fix problem with deployments and long branch names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,14 @@ commands:
             next_release_name=`silta ci release name --release-suffix next`
 
             # If name is too long, truncate it and append a hash
+            if [ ${#drupal_release_name} -ge 34 ]; then
+              drupal_release_name="$(printf "$drupal_release_name" | cut -c 1-33)$(printf "$drupal_release_name" | shasum -a 256 | cut -c 1-3 )"
+            fi
+            if [ ${#next_release_name} -ge 34 ]; then
+              next_release_name="$(printf "$next_release_name" | cut -c 1-33)$(printf "$next_release_name" | shasum -a 256 | cut -c 1-3 )"
+            fi
+            
+            # If name is too long, truncate it and append a hash
             if [ ${#drupal_release_name} -ge 33 ]; then
               drupal_release_name="$(printf "$drupal_release_name" | cut -c 1-30)$(printf "$drupal_release_name" | shasum -a 256 | cut -c 1-3 )"
             if [ ${#drupal_release_name} -ge 34 ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,18 +132,6 @@ commands:
             if [ ${#next_release_name} -ge 34 ]; then
               next_release_name="$(printf "$next_release_name" | cut -c 1-33)$(printf "$next_release_name" | shasum -a 256 | cut -c 1-3 )"
             fi
-            
-            # If name is too long, truncate it and append a hash
-            if [ ${#drupal_release_name} -ge 33 ]; then
-              drupal_release_name="$(printf "$drupal_release_name" | cut -c 1-30)$(printf "$drupal_release_name" | shasum -a 256 | cut -c 1-3 )"
-            if [ ${#drupal_release_name} -ge 34 ]; then
-              drupal_release_name="$(printf "$drupal_release_name" | cut -c 1-33)$(printf "$drupal_release_name" | shasum -a 256 | cut -c 1-3 )"
-            fi
-            if [ ${#next_release_name} -ge 33 ]; then
-              next_release_name="$(printf "$next_release_name" | cut -c 1-30)$(printf "$next_release_name" | shasum -a 256 | cut -c 1-3 )"
-            if [ ${#next_release_name} -ge 34 ]; then
-              next_release_name="$(printf "$next_release_name" | cut -c 1-33)$(printf "$next_release_name" | shasum -a 256 | cut -c 1-3 )"
-            fi
 
             project_name=next-drupal-starterkit
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,9 +128,13 @@ commands:
             # If name is too long, truncate it and append a hash
             if [ ${#drupal_release_name} -ge 33 ]; then
               drupal_release_name="$(printf "$drupal_release_name" | cut -c 1-30)$(printf "$drupal_release_name" | shasum -a 256 | cut -c 1-3 )"
+            if [ ${#drupal_release_name} -ge 34 ]; then
+              drupal_release_name="$(printf "$drupal_release_name" | cut -c 1-33)$(printf "$drupal_release_name" | shasum -a 256 | cut -c 1-3 )"
             fi
             if [ ${#next_release_name} -ge 33 ]; then
               next_release_name="$(printf "$next_release_name" | cut -c 1-30)$(printf "$next_release_name" | shasum -a 256 | cut -c 1-3 )"
+            if [ ${#next_release_name} -ge 34 ]; then
+              next_release_name="$(printf "$next_release_name" | cut -c 1-33)$(printf "$next_release_name" | shasum -a 256 | cut -c 1-3 )"
             fi
 
             project_name=next-drupal-starterkit


### PR DESCRIPTION
## Link to ticket:

https://wunder.atlassian.net/browse/NEX-134

## What this adds
Fix the logic generating the special NEXT_DOMAIN and DRUPAL_DOMAIN env var values. This removes the mismatch between expected and actual domain values in case of a long branch names (which happens quite often) as those get truncated due to length limitation and a hash suffix is appended.

This solution was found by @k4lv15 for another project.


