### PR TITLE
NEX-134: Truncate release names only if 36 or more characters long

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,10 +126,10 @@ commands:
             next_release_name=`silta ci release name --release-suffix next`
 
             # If name is too long, truncate it and append a hash
-            if [ ${#drupal_release_name} -ge 34 ]; then
+            if [ ${#drupal_release_name} -ge 36 ]; then
               drupal_release_name="$(printf "$drupal_release_name" | cut -c 1-33)$(printf "$drupal_release_name" | shasum -a 256 | cut -c 1-3 )"
             fi
-            if [ ${#next_release_name} -ge 34 ]; then
+            if [ ${#next_release_name} -ge 36 ]; then
               next_release_name="$(printf "$next_release_name" | cut -c 1-33)$(printf "$next_release_name" | shasum -a 256 | cut -c 1-3 )"
             fi
 


### PR DESCRIPTION
## Link to ticket:

https://wunder.atlassian.net/browse/NEX-134 

## Link to feature environment:

https://app.circleci.com/pipelines/github/wunderio/next-drupal-starterkit?branch=feature%2FNEX-134-follow-up

## Changes proposed in this PR:

This is a followup for #174 fixing some additional edge cases discovered in another project where expected and actual domains still didn't match.

