### PR TITLE
NEX-137: Add the path of the sitemap to the list of excluded paths fo…

### DIFF
--- a/drupal/recipes/wunder_next_setup/config/require_login.settings.yml
+++ b/drupal/recipes/wunder_next_setup/config/require_login.settings.yml
@@ -11,7 +11,7 @@ requirements:
   request_path:
     id: request_path
     negate: true
-    pages: "/subrequests/*\r\n/jsonapi\r\n/jsonapi/*\r\n/router/translate-path\r\n/next/preview-url\r\n/oauth/*\r\n/wunder_search/proxy\r\n/webform_rest/*\r\n/user/register\r\n/user/reset\r\n/user/reset/*\r\n/graphql\r\n"
+    pages: "/subrequests/*\r\n/jsonapi\r\n/jsonapi/*\r\n/router/translate-path\r\n/next/preview-url\r\n/oauth/*\r\n/wunder_search/proxy\r\n/webform_rest/*\r\n/user/register\r\n/user/reset\r\n/user/reset/*\r\n/graphql\r\n/sites/default/files/sitemap.xml"
   webform:
     id: webform
     negate: false


### PR DESCRIPTION
The sitemap functionality works like this: 
1. drupal generates the sitemap, puts it in its files folder
2. next.js has a rewrite pointing to that path

But, because we have the require_login module in place, currently going to that path results in a redirect like this: 

https://next-drupal-starterkit.dev.wdr.io/en/user/login?destination=/sites/default/files/sitemap.xml

The solution is to add /sites/default/files/sitemap.xml to the list of excluded paths.