### PR TITLE
Revert "NEX-121: Prevent lando memory limit errors during local development"

### DIFF
--- a/drupal/web/sites/default/settings.php
+++ b/drupal/web/sites/default/settings.php
@@ -28,11 +28,6 @@ $settings['config_sync_directory'] = '../config/sync';
 // Load services definition file.
 $settings['container_yamls'][] = $app_root . '/' . $site_path . '/services.yml';
 
-// Raise memory limit for drush.
-if (PHP_SAPI === 'cli') {
-  ini_set('memory_limit', '768M');
-}
-
 /**
  * The default list of directories that will be ignored by Drupal's file API.
  *


### PR DESCRIPTION
Reverts wunderio/next-drupal-starterkit#184

This PR was meant to fix an issue with lando 3.21 where the memory limit was dropped to 128m, but in v3.21.0-beta.4 the limit is set back to -1.
