### PR TITLE
Add relalidate when returning a 404 for slug and frontpage

### DIFF
--- a/next/pages/[...slug].tsx
+++ b/next/pages/[...slug].tsx
@@ -123,6 +123,7 @@ export const getStaticProps: GetStaticProps<PageProps> = async (context) => {
   if (!nodeEntity) {
     return {
       notFound: true,
+      revalidate: 60,
     };
   }
 
@@ -162,6 +163,7 @@ export const getStaticProps: GetStaticProps<PageProps> = async (context) => {
     if (!nodeEntity) {
       return {
         notFound: true,
+        revalidate: 60,
       };
     }
   }
@@ -170,6 +172,7 @@ export const getStaticProps: GetStaticProps<PageProps> = async (context) => {
   if (!isPreview && nodeEntity.status !== true) {
     return {
       notFound: true,
+      revalidate: 60,
     };
   }
 

--- a/next/pages/index.tsx
+++ b/next/pages/index.tsx
@@ -70,6 +70,7 @@ export const getStaticProps: GetStaticProps<HomepageProps> = async (
   if (!frontpage || !(frontpage.__typename === "NodeFrontpage")) {
     return {
       notFound: true,
+      revalidate: 10,
     };
   }
 
@@ -77,6 +78,7 @@ export const getStaticProps: GetStaticProps<HomepageProps> = async (
   if (!context.preview && frontpage.status !== true) {
     return {
       notFound: true,
+      revalidate: 10,
     };
   }
 


### PR DESCRIPTION
When returning a 404 in pages that are generated using ISR, you should add a revalidate.

In this branch, we add 10 seconds for frontpage (since it's more critical) and the same 60 seconds for any page