### PR TITLE
NEX-142: Update to drush 12, drupal 10.2.4 + misc fixes

### DIFF
--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -143,7 +143,7 @@
                 "Add the langcode field to the menu_item entity in graphql (local patch)": "./patches/grapqhl_compose_add_langcode_to_menu_item.patch"
             },
             "drupal/core": {
-                "Add support for the experimental recipes functionality": "https://git.drupalcode.org/project/distributions_recipes/-/raw/patch/recipe-10.2.x.patch?cachebuster=1",
+                "Add support for the experimental recipes functionality (local patch)": "./patches/recipe-10.2.x.patch",
                 "Fix error when enabling the language module via recipe": "https://www.drupal.org/files/issues/2019-11-19/drupal.8.8.x-3002532-20.patch",
                 "Do not set user as blocked when created via REST": "https://www.drupal.org/files/issues/2022-08-17/3055807-47.patch"
             }

--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -19,8 +19,8 @@
         "composer/installers": "^2.1",
         "cweagans/composer-patches": "^1.7",
         "drupal/admin_toolbar": "^3.4",
-        "drupal/core-composer-scaffold": "^10.0",
-        "drupal/core-recommended": "^10.0",
+        "drupal/core-composer-scaffold": "^10.2",
+        "drupal/core-recommended": "^10.2",
         "drupal/elasticsearch_helper": "^8.1",
         "drupal/graphql_compose": "^2.1@beta",
         "drupal/menu_link_attributes": "^1.3",
@@ -42,14 +42,14 @@
         "drupal/token": "^1.13",
         "drupal/webform": "^6.2",
         "drupal/webform_rest": "^4.0",
-        "drush/drush": "^11.4",
+        "drush/drush": "^12",
         "elasticsearch/elasticsearch": "^8.9",
         "vlucas/phpdotenv": "^5.4",
         "webflo/drupal-finder": "^1.2",
         "wunderio/drupal-ping": "^2.4"
     },
     "require-dev": {
-        "drupal/core-dev": "^10.0",
+        "drupal/core-dev": "^10.2",
         "wunderio/code-quality": "^2.2"
     },
     "conflict": {
@@ -133,7 +133,8 @@
                 "#3111456-59 - Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-12-01/decouple_router-3111456-resolve-language-issue-58--get-translation.patch"
             },
             "drupal/paragraphs": {
-                "Paragraphs (stable) title from form options not being applied (issue #3401581)": "https://www.drupal.org/files/issues/2023-11-14/paragraphs-custom-title-not-displayed-3401581-2.patch"
+                "Paragraphs (stable) title from form options not being applied (issue #3401581)": "https://www.drupal.org/files/issues/2023-11-14/paragraphs-custom-title-not-displayed-3401581-2.patch",
+                "Weight fields appear when editing a translation even if the order can't be changed": "https://www.drupal.org/files/issues/2024-03-04/paragraphs_fix_tabledrag_3425348-3.patch"
             },
             "drupal/graphql" : {
                 "drupal-graphql#1323: Add check for translation (from Github)": "https://patch-diff.githubusercontent.com/raw/drupal-graphql/graphql/pull/1388.patch"
@@ -142,7 +143,7 @@
                 "Add the langcode field to the menu_item entity in graphql (local patch)": "./patches/grapqhl_compose_add_langcode_to_menu_item.patch"
             },
             "drupal/core": {
-                "Add support for the experimental recipes functionality": "https://git.drupalcode.org/project/distributions_recipes/-/raw/patch/recipe.patch",
+                "Add support for the experimental recipes functionality": "https://git.drupalcode.org/project/distributions_recipes/-/raw/patch/recipe-10.2.x.patch",
                 "Fix error when enabling the language module via recipe": "https://www.drupal.org/files/issues/2019-11-19/drupal.8.8.x-3002532-20.patch",
                 "Do not set user as blocked when created via REST": "https://www.drupal.org/files/issues/2022-08-17/3055807-47.patch"
             }

--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -143,7 +143,7 @@
                 "Add the langcode field to the menu_item entity in graphql (local patch)": "./patches/grapqhl_compose_add_langcode_to_menu_item.patch"
             },
             "drupal/core": {
-                "Add support for the experimental recipes functionality": "https://git.drupalcode.org/project/distributions_recipes/-/raw/patch/recipe-10.2.x.patch",
+                "Add support for the experimental recipes functionality": "https://git.drupalcode.org/project/distributions_recipes/-/raw/patch/recipe-10.2.x.patch?cachebuster=1",
                 "Fix error when enabling the language module via recipe": "https://www.drupal.org/files/issues/2019-11-19/drupal.8.8.x-3002532-20.patch",
                 "Do not set user as blocked when created via REST": "https://www.drupal.org/files/issues/2022-08-17/3055807-47.patch"
             }

--- a/drupal/composer.lock
+++ b/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4e4ad1dfabf7d0d8e69a9e39264e1d24",
+    "content-hash": "21ba2a01b8fae2afec50ffdf789edd5f",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/drupal/composer.lock
+++ b/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9a08636624f67898a389b3c5de9d86e2",
+    "content-hash": "4e4ad1dfabf7d0d8e69a9e39264e1d24",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/drupal/composer.lock
+++ b/drupal/composer.lock
@@ -2844,17 +2844,17 @@
         },
         {
             "name": "drupal/registration_role",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/registration_role.git",
-                "reference": "2.0.0"
+                "reference": "2.0.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/registration_role-2.0.0.zip",
-                "reference": "2.0.0",
-                "shasum": "3d3b9d1068e80a47e14e0e1d64498bf1e0d3075c"
+                "url": "https://ftp.drupal.org/files/projects/registration_role-2.0.1.zip",
+                "reference": "2.0.1",
+                "shasum": "fbc76f993f8ca186aec1989467dafa6bed520077"
             },
             "require": {
                 "drupal/core": "^8 || ^9 || ^10"
@@ -2862,8 +2862,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.0",
-                    "datestamp": "1689039865",
+                    "version": "2.0.1",
+                    "datestamp": "1709745969",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -16011,5 +16011,5 @@
         "php": ">=8.2"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/drupal/composer.lock
+++ b/drupal/composer.lock
@@ -4,35 +4,35 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c7bb025683590c43c17d19232b8a466f",
+    "content-hash": "1aaf84202389c4ef6a845b48f458d95a",
     "packages": [
         {
             "name": "asm89/stack-cors",
-            "version": "v2.1.1",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/asm89/stack-cors.git",
-                "reference": "73e5b88775c64ccc0b84fb60836b30dc9d92ac4a"
+                "reference": "50f57105bad3d97a43ec4a485eb57daf347eafea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/asm89/stack-cors/zipball/73e5b88775c64ccc0b84fb60836b30dc9d92ac4a",
-                "reference": "73e5b88775c64ccc0b84fb60836b30dc9d92ac4a",
+                "url": "https://api.github.com/repos/asm89/stack-cors/zipball/50f57105bad3d97a43ec4a485eb57daf347eafea",
+                "reference": "50f57105bad3d97a43ec4a485eb57daf347eafea",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8.0",
-                "symfony/http-foundation": "^4|^5|^6",
-                "symfony/http-kernel": "^4|^5|^6"
+                "php": "^7.3|^8.0",
+                "symfony/http-foundation": "^5.3|^6|^7",
+                "symfony/http-kernel": "^5.3|^6|^7"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7|^9",
+                "phpunit/phpunit": "^9",
                 "squizlabs/php_codesniffer": "^3.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "2.2-dev"
                 }
             },
             "autoload": {
@@ -58,55 +58,54 @@
             ],
             "support": {
                 "issues": "https://github.com/asm89/stack-cors/issues",
-                "source": "https://github.com/asm89/stack-cors/tree/v2.1.1"
+                "source": "https://github.com/asm89/stack-cors/tree/v2.2.0"
             },
-            "time": "2022-01-18T09:12:03+00:00"
+            "time": "2023-11-14T13:51:46+00:00"
         },
         {
             "name": "chi-teck/drupal-code-generator",
-            "version": "2.6.2",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Chi-teck/drupal-code-generator.git",
-                "reference": "22ed1cc02dc47814e8239de577da541e9b9bd980"
+                "reference": "56da9209b24a5a5b5d27bec9e523f02bdd101770"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Chi-teck/drupal-code-generator/zipball/22ed1cc02dc47814e8239de577da541e9b9bd980",
-                "reference": "22ed1cc02dc47814e8239de577da541e9b9bd980",
+                "url": "https://api.github.com/repos/Chi-teck/drupal-code-generator/zipball/56da9209b24a5a5b5d27bec9e523f02bdd101770",
+                "reference": "56da9209b24a5a5b5d27bec9e523f02bdd101770",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "php": ">=7.4",
-                "psr/log": "^1.1 || ^2.0 || ^3.0",
-                "symfony/console": "^4.4.15 || ^5.1 || ^6.0",
-                "symfony/filesystem": "^4.4 || ^5.1 || ^6",
-                "symfony/polyfill-php80": "^1.23",
-                "symfony/string": "^5.1 || ^6",
-                "twig/twig": "^2.14.11 || ^3.1"
+                "php": ">=8.1.0",
+                "psr/event-dispatcher": "^1.0",
+                "psr/log": "^3.0",
+                "symfony/console": "^6.3",
+                "symfony/dependency-injection": "^6.3.2",
+                "symfony/filesystem": "^6.3",
+                "symfony/string": "^6.3",
+                "twig/twig": "^3.4"
             },
             "conflict": {
                 "squizlabs/php_codesniffer": "<3.6"
             },
             "require-dev": {
-                "chi-teck/drupal-coder-extension": "^1.2",
-                "drupal/coder": "^8.3.14",
+                "chi-teck/drupal-coder-extension": "^2.0.0-alpha4",
+                "drupal/coder": "8.3.22",
+                "drupal/core": "10.1.x-dev",
+                "ext-simplexml": "*",
                 "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.4",
-                "squizlabs/php_codesniffer": "^3.5",
-                "symfony/var-dumper": "^5.2 || ^6.0",
-                "symfony/yaml": "^5.2 || ^6.0"
+                "phpunit/phpunit": "^9.5",
+                "squizlabs/php_codesniffer": "^3.7",
+                "symfony/var-dumper": "^6.3",
+                "symfony/yaml": "^6.3",
+                "vimeo/psalm": "^5.14.0"
             },
             "bin": [
                 "bin/dcg"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "DrupalCodeGenerator\\": "src"
@@ -119,9 +118,9 @@
             "description": "Drupal code generator",
             "support": {
                 "issues": "https://github.com/Chi-teck/drupal-code-generator/issues",
-                "source": "https://github.com/Chi-teck/drupal-code-generator/tree/2.6.2"
+                "source": "https://github.com/Chi-teck/drupal-code-generator/tree/3.3.0"
             },
-            "time": "2022-11-11T15:34:04+00:00"
+            "time": "2023-10-21T12:57:05+00:00"
         },
         {
             "name": "composer/installers",
@@ -270,16 +269,16 @@
         },
         {
             "name": "composer/semver",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9"
+                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/3953f23262f2bff1919fc82183ad9acb13ff62c9",
-                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9",
+                "url": "https://api.github.com/repos/composer/semver/zipball/35e8d0af4486141bc745f23a29cc2091eb624a32",
+                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32",
                 "shasum": ""
             },
             "require": {
@@ -329,9 +328,9 @@
                 "versioning"
             ],
             "support": {
-                "irc": "irc://irc.freenode.org/composer",
+                "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.3.2"
+                "source": "https://github.com/composer/semver/tree/3.4.0"
             },
             "funding": [
                 {
@@ -347,7 +346,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-01T19:23:25+00:00"
+            "time": "2023-08-31T09:50:34+00:00"
         },
         {
             "name": "consolidation/annotated-command",
@@ -1180,16 +1179,16 @@
         },
         {
             "name": "doctrine/inflector",
-            "version": "2.0.9",
+            "version": "2.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "2930cd5ef353871c821d5c43ed030d39ac8cfe65"
+                "reference": "5817d0659c5b50c9b950feb9af7b9668e2c436bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/2930cd5ef353871c821d5c43ed030d39ac8cfe65",
-                "reference": "2930cd5ef353871c821d5c43ed030d39ac8cfe65",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/5817d0659c5b50c9b950feb9af7b9668e2c436bc",
+                "reference": "5817d0659c5b50c9b950feb9af7b9668e2c436bc",
                 "shasum": ""
             },
             "require": {
@@ -1251,7 +1250,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/inflector/issues",
-                "source": "https://github.com/doctrine/inflector/tree/2.0.9"
+                "source": "https://github.com/doctrine/inflector/tree/2.0.10"
             },
             "funding": [
                 {
@@ -1267,7 +1266,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-15T18:05:13+00:00"
+            "time": "2024-02-18T20:23:39+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -1478,16 +1477,16 @@
         },
         {
             "name": "drupal/core",
-            "version": "10.1.8",
+            "version": "10.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core.git",
-                "reference": "fe4fd82ecd1f70db397c58d4360e15de0b4785c7"
+                "reference": "d1c5b44adfc79bda03252471491b0fba89d87eff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core/zipball/fe4fd82ecd1f70db397c58d4360e15de0b4785c7",
-                "reference": "fe4fd82ecd1f70db397c58d4360e15de0b4785c7",
+                "url": "https://api.github.com/repos/drupal/core/zipball/d1c5b44adfc79bda03252471491b0fba89d87eff",
+                "reference": "d1c5b44adfc79bda03252471491b0fba89d87eff",
                 "shasum": ""
             },
             "require": {
@@ -1517,23 +1516,26 @@
                 "php": ">=8.1.0",
                 "psr/log": "^3.0",
                 "sebastian/diff": "^4",
-                "symfony/console": "^6.3",
-                "symfony/dependency-injection": "^6.3",
-                "symfony/event-dispatcher": "^6.3",
-                "symfony/http-foundation": "^6.3",
-                "symfony/http-kernel": "^6.3",
-                "symfony/mime": "^6.3",
+                "symfony/console": "^6.4",
+                "symfony/dependency-injection": "^6.4",
+                "symfony/event-dispatcher": "^6.4",
+                "symfony/filesystem": "^6.4",
+                "symfony/finder": "^6.4",
+                "symfony/http-foundation": "^6.4",
+                "symfony/http-kernel": "^6.4",
+                "symfony/mailer": "^6.4",
+                "symfony/mime": "^6.4",
                 "symfony/polyfill-iconv": "^1.26",
-                "symfony/process": "^6.3",
-                "symfony/psr-http-message-bridge": "^2.1",
-                "symfony/routing": "^6.3",
-                "symfony/serializer": "^6.3",
-                "symfony/validator": "^6.3",
-                "symfony/yaml": "^6.3",
+                "symfony/process": "^6.4",
+                "symfony/psr-http-message-bridge": "^2.1|^6.4",
+                "symfony/routing": "^6.4",
+                "symfony/serializer": "^6.4",
+                "symfony/validator": "^6.4",
+                "symfony/yaml": "^6.4",
                 "twig/twig": "^3.5.0"
             },
             "conflict": {
-                "drush/drush": "<8.1.10"
+                "drush/drush": "<12.4.3"
             },
             "replace": {
                 "drupal/core-annotation": "self.version",
@@ -1632,13 +1634,13 @@
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
             "support": {
-                "source": "https://github.com/drupal/core/tree/10.1.8"
+                "source": "https://github.com/drupal/core/tree/10.2.4"
             },
-            "time": "2024-01-16T21:11:11+00:00"
+            "time": "2024-03-06T08:23:56+00:00"
         },
         {
             "name": "drupal/core-composer-scaffold",
-            "version": "10.2.3",
+            "version": "10.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-composer-scaffold.git",
@@ -1682,76 +1684,80 @@
                 "drupal"
             ],
             "support": {
-                "source": "https://github.com/drupal/core-composer-scaffold/tree/10.2.3"
+                "source": "https://github.com/drupal/core-composer-scaffold/tree/10.2.4"
             },
             "time": "2024-01-26T14:59:30+00:00"
         },
         {
             "name": "drupal/core-recommended",
-            "version": "10.1.8",
+            "version": "10.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-recommended.git",
-                "reference": "0e4a17b65e5dd2aedf66461e7c3658a35adc4924"
+                "reference": "550c4cb19afda15ef892d88469ab93dc38bf0b46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/0e4a17b65e5dd2aedf66461e7c3658a35adc4924",
-                "reference": "0e4a17b65e5dd2aedf66461e7c3658a35adc4924",
+                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/550c4cb19afda15ef892d88469ab93dc38bf0b46",
+                "reference": "550c4cb19afda15ef892d88469ab93dc38bf0b46",
                 "shasum": ""
             },
             "require": {
-                "asm89/stack-cors": "~v2.1.1",
-                "composer/semver": "~3.3.2",
+                "asm89/stack-cors": "~v2.2.0",
+                "composer/semver": "~3.4.0",
                 "doctrine/annotations": "~1.14.3",
-                "doctrine/deprecations": "~v1.1.1",
+                "doctrine/deprecations": "~1.1.2",
                 "doctrine/lexer": "~2.1.0",
-                "drupal/core": "10.1.8",
-                "egulias/email-validator": "~4.0.1",
-                "guzzlehttp/guzzle": "~7.7.0",
-                "guzzlehttp/psr7": "~2.5.0",
-                "masterminds/html5": "~2.8.0",
+                "drupal/core": "10.2.4",
+                "egulias/email-validator": "~4.0.2",
+                "guzzlehttp/guzzle": "~7.8.1",
+                "guzzlehttp/promises": "~2.0.2",
+                "guzzlehttp/psr7": "~2.6.2",
+                "masterminds/html5": "~2.8.1",
                 "mck89/peast": "~v1.15.4",
                 "pear/archive_tar": "~1.4.14",
                 "pear/console_getopt": "~v1.4.3",
-                "pear/pear-core-minimal": "~v1.10.13",
+                "pear/pear-core-minimal": "~v1.10.14",
                 "pear/pear_exception": "~v1.0.2",
                 "psr/cache": "~3.0.0",
                 "psr/container": "~2.0.2",
                 "psr/event-dispatcher": "~1.0.0",
-                "psr/http-client": "~1.0.2",
+                "psr/http-client": "~1.0.3",
                 "psr/http-factory": "~1.0.2",
                 "psr/log": "~3.0.0",
                 "ralouphie/getallheaders": "~3.0.3",
                 "sebastian/diff": "~4.0.5",
-                "symfony/console": "~v6.3.0",
-                "symfony/dependency-injection": "~v6.3.0",
-                "symfony/deprecation-contracts": "~v3.3.0",
-                "symfony/error-handler": "~v6.3.0",
-                "symfony/event-dispatcher": "~v6.3.0",
-                "symfony/event-dispatcher-contracts": "~v3.3.0",
-                "symfony/http-foundation": "~v6.3.0",
-                "symfony/http-kernel": "~v6.3.0",
-                "symfony/mime": "~v6.3.0",
-                "symfony/polyfill-ctype": "~v1.27.0",
-                "symfony/polyfill-iconv": "~v1.27.0",
-                "symfony/polyfill-intl-grapheme": "~v1.27.0",
-                "symfony/polyfill-intl-idn": "~v1.27.0",
-                "symfony/polyfill-intl-normalizer": "~v1.27.0",
-                "symfony/polyfill-mbstring": "~v1.27.0",
-                "symfony/polyfill-php83": "~v1.27.0",
-                "symfony/process": "~v6.3.0",
-                "symfony/psr-http-message-bridge": "~v2.2.0",
-                "symfony/routing": "~v6.3.0",
-                "symfony/serializer": "~v6.3.0",
-                "symfony/service-contracts": "~v3.3.0",
-                "symfony/string": "~v6.3.0",
-                "symfony/translation-contracts": "~v3.3.0",
-                "symfony/validator": "~v6.3.0",
-                "symfony/var-dumper": "~v6.3.0",
-                "symfony/var-exporter": "~v6.3.0",
-                "symfony/yaml": "~v6.3.0",
-                "twig/twig": "~v3.6.0"
+                "symfony/console": "~v6.4.1",
+                "symfony/dependency-injection": "~v6.4.1",
+                "symfony/deprecation-contracts": "~v3.4.0",
+                "symfony/error-handler": "~v6.4.0",
+                "symfony/event-dispatcher": "~v6.4.0",
+                "symfony/event-dispatcher-contracts": "~v3.4.0",
+                "symfony/filesystem": "~v6.4.0",
+                "symfony/finder": "~v6.4.0",
+                "symfony/http-foundation": "~v6.4.0",
+                "symfony/http-kernel": "~v6.4.1",
+                "symfony/mailer": "~v6.4.0",
+                "symfony/mime": "~v6.4.0",
+                "symfony/polyfill-ctype": "~v1.28.0",
+                "symfony/polyfill-iconv": "~v1.28.0",
+                "symfony/polyfill-intl-grapheme": "~v1.28.0",
+                "symfony/polyfill-intl-idn": "~v1.28.0",
+                "symfony/polyfill-intl-normalizer": "~v1.28.0",
+                "symfony/polyfill-mbstring": "~v1.28.0",
+                "symfony/polyfill-php83": "~v1.28.0",
+                "symfony/process": "~v6.4.0",
+                "symfony/psr-http-message-bridge": "~v6.4.0",
+                "symfony/routing": "~v6.4.1",
+                "symfony/serializer": "~v6.4.1",
+                "symfony/service-contracts": "~v3.4.0",
+                "symfony/string": "~v6.4.0",
+                "symfony/translation-contracts": "~v3.4.0",
+                "symfony/validator": "~v6.4.0",
+                "symfony/var-dumper": "~v6.4.0",
+                "symfony/var-exporter": "~v6.4.1",
+                "symfony/yaml": "~v6.4.0",
+                "twig/twig": "~v3.8.0"
             },
             "conflict": {
                 "webflo/drupal-core-strict": "*"
@@ -1763,9 +1769,9 @@
             ],
             "description": "Core and its dependencies with known-compatible minor versions. Require this project INSTEAD OF drupal/core.",
             "support": {
-                "source": "https://github.com/drupal/core-recommended/tree/10.1.8"
+                "source": "https://github.com/drupal/core-recommended/tree/10.2.4"
             },
-            "time": "2024-01-16T21:11:11+00:00"
+            "time": "2024-03-06T08:23:56+00:00"
         },
         {
             "name": "drupal/ctools",
@@ -3535,57 +3541,55 @@
         },
         {
             "name": "drush/drush",
-            "version": "11.6.0",
+            "version": "12.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drush-ops/drush.git",
-                "reference": "f301df5dec8d2aacb03d3e01e0ffc6d98e10ae78"
+                "reference": "8245acede57ecc62a90aa0f19ff3b29e5f11f971"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drush-ops/drush/zipball/f301df5dec8d2aacb03d3e01e0ffc6d98e10ae78",
-                "reference": "f301df5dec8d2aacb03d3e01e0ffc6d98e10ae78",
+                "url": "https://api.github.com/repos/drush-ops/drush/zipball/8245acede57ecc62a90aa0f19ff3b29e5f11f971",
+                "reference": "8245acede57ecc62a90aa0f19ff3b29e5f11f971",
                 "shasum": ""
             },
             "require": {
-                "chi-teck/drupal-code-generator": "^2.4",
+                "chi-teck/drupal-code-generator": "^3.0",
+                "composer-runtime-api": "^2.2",
                 "composer/semver": "^1.4 || ^3",
-                "consolidation/annotated-command": "^4.8.2",
-                "consolidation/config": "^2",
-                "consolidation/filter-via-dot-access-data": "^2",
-                "consolidation/robo": "^3.0.9 || ^4.0.1",
-                "consolidation/site-alias": "^3.1.6 || ^4",
-                "consolidation/site-process": "^4.1.3 || ^5",
-                "enlightn/security-checker": "^1",
+                "consolidation/annotated-command": "^4.9.1",
+                "consolidation/config": "^2.1.2",
+                "consolidation/filter-via-dot-access-data": "^2.0.2",
+                "consolidation/output-formatters": "^4.3.2",
+                "consolidation/robo": "^4.0.6",
+                "consolidation/site-alias": "^4",
+                "consolidation/site-process": "^5.2.0",
                 "ext-dom": "*",
-                "guzzlehttp/guzzle": "^6.5 || ^7.0",
-                "league/container": "^3.4 || ^4",
-                "php": ">=7.4",
+                "grasmash/yaml-cli": "^3.1",
+                "guzzlehttp/guzzle": "^7.0",
+                "league/container": "^4",
+                "php": ">=8.1",
                 "psy/psysh": "~0.11",
-                "symfony/event-dispatcher": "^4.0 || ^5.0 || ^6.0",
-                "symfony/filesystem": "^4.4 || ^5.4 || ^6.1",
-                "symfony/finder": "^4.0 || ^5 || ^6",
-                "symfony/polyfill-php80": "^1.23",
-                "symfony/var-dumper": "^4.0 || ^5.0 || ^6.0",
-                "symfony/yaml": "^4.0 || ^5.0 || ^6.0",
+                "symfony/event-dispatcher": "^6",
+                "symfony/filesystem": "^6.1",
+                "symfony/finder": "^6",
+                "symfony/var-dumper": "^6.0",
+                "symfony/yaml": "^6.0",
                 "webflo/drupal-finder": "^1.2"
             },
             "conflict": {
-                "drupal/core": "< 9.2",
+                "drupal/core": "< 10.0",
                 "drupal/migrate_run": "*",
                 "drupal/migrate_tools": "<= 5"
             },
             "require-dev": {
-                "composer/installers": "^1.7",
+                "composer/installers": "^2",
                 "cweagans/composer-patches": "~1.0",
-                "david-garcia/phpwhois": "4.3.0",
-                "drupal/core-recommended": "^9 || ^10",
+                "drupal/core-recommended": "^10",
                 "drupal/semver_example": "2.3.0",
-                "phpunit/phpunit": ">=7.5.20",
+                "phpunit/phpunit": "^9",
                 "rector/rector": "^0.12",
-                "squizlabs/php_codesniffer": "^3.6",
-                "vlucas/phpdotenv": "^2.4",
-                "yoast/phpunit-polyfills": "^0.2.0"
+                "squizlabs/php_codesniffer": "^3.7"
             },
             "bin": [
                 "drush"
@@ -3667,8 +3671,9 @@
             "support": {
                 "forum": "http://drupal.stackexchange.com/questions/tagged/drush",
                 "issues": "https://github.com/drush-ops/drush/issues",
+                "security": "https://github.com/drush-ops/drush/security/advisories",
                 "slack": "https://drupal.slack.com/messages/C62H9CWQM",
-                "source": "https://github.com/drush-ops/drush/tree/11.6.0"
+                "source": "https://github.com/drush-ops/drush/tree/12.4.3"
             },
             "funding": [
                 {
@@ -3676,7 +3681,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-06-06T18:46:18+00:00"
+            "time": "2023-11-16T22:57:24+00:00"
         },
         {
             "name": "egulias/email-validator",
@@ -3850,72 +3855,6 @@
             "time": "2024-01-26T14:58:39+00:00"
         },
         {
-            "name": "enlightn/security-checker",
-            "version": "v1.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/enlightn/security-checker.git",
-                "reference": "68df5c7256c84b428bf8fcff0d249de06ce362d2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/enlightn/security-checker/zipball/68df5c7256c84b428bf8fcff0d249de06ce362d2",
-                "reference": "68df5c7256c84b428bf8fcff0d249de06ce362d2",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "guzzlehttp/guzzle": "^6.3|^7.0",
-                "php": ">=5.6",
-                "symfony/console": "^3.4|^4|^5|^6|^7",
-                "symfony/finder": "^3|^4|^5|^6|^7",
-                "symfony/process": "^3.4|^4|^5|^6|^7",
-                "symfony/yaml": "^3.4|^4|^5|^6|^7"
-            },
-            "require-dev": {
-                "ext-zip": "*",
-                "friendsofphp/php-cs-fixer": "^2.18|^3.0",
-                "phpunit/phpunit": "^5.5|^6|^7|^8|^9"
-            },
-            "bin": [
-                "security-checker"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Enlightn\\SecurityChecker\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Paras Malhotra",
-                    "email": "paras@laravel-enlightn.com"
-                },
-                {
-                    "name": "Miguel Piedrafita",
-                    "email": "soy@miguelpiedrafita.com"
-                }
-            ],
-            "description": "A PHP dependency vulnerabilities scanner based on the Security Advisories Database.",
-            "keywords": [
-                "package",
-                "php",
-                "scanner",
-                "security",
-                "security advisories",
-                "vulnerability scanner"
-            ],
-            "support": {
-                "issues": "https://github.com/enlightn/security-checker/issues",
-                "source": "https://github.com/enlightn/security-checker/tree/v1.11.0"
-            },
-            "time": "2023-11-17T07:53:29+00:00"
-        },
-        {
             "name": "galbar/jsonpath",
             "version": "1.3.1",
             "source": {
@@ -4082,23 +4021,79 @@
             "time": "2022-05-10T13:14:49+00:00"
         },
         {
-            "name": "guzzlehttp/guzzle",
-            "version": "7.7.1",
+            "name": "grasmash/yaml-cli",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "085b026db54d4b5012f727c80c9958e8b8cbc454"
+                "url": "https://github.com/grasmash/yaml-cli.git",
+                "reference": "00f3fd775f6abbfacd44432f1999c3c3b02791f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/085b026db54d4b5012f727c80c9958e8b8cbc454",
-                "reference": "085b026db54d4b5012f727c80c9958e8b8cbc454",
+                "url": "https://api.github.com/repos/grasmash/yaml-cli/zipball/00f3fd775f6abbfacd44432f1999c3c3b02791f0",
+                "reference": "00f3fd775f6abbfacd44432f1999c3c3b02791f0",
+                "shasum": ""
+            },
+            "require": {
+                "dflydev/dot-access-data": "^3",
+                "php": ">=8.0",
+                "symfony/console": "^6",
+                "symfony/filesystem": "^6",
+                "symfony/yaml": "^6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2",
+                "phpunit/phpunit": "^9",
+                "squizlabs/php_codesniffer": "^3.0"
+            },
+            "bin": [
+                "bin/yaml-cli"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Grasmash\\YamlCli\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Grasmick"
+                }
+            ],
+            "description": "A command line tool for reading and manipulating yaml files.",
+            "support": {
+                "issues": "https://github.com/grasmash/yaml-cli/issues",
+                "source": "https://github.com/grasmash/yaml-cli/tree/3.1.0"
+            },
+            "time": "2022-05-09T20:22:34+00:00"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "41042bc7ab002487b876a0683fc8dce04ddce104"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/41042bc7ab002487b876a0683fc8dce04ddce104",
+                "reference": "41042bc7ab002487b876a0683fc8dce04ddce104",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^1.5.3 || ^2.0",
-                "guzzlehttp/psr7": "^1.9.1 || ^2.4.5",
+                "guzzlehttp/promises": "^1.5.3 || ^2.0.1",
+                "guzzlehttp/psr7": "^1.9.1 || ^2.5.1",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.2 || ^3.0"
@@ -4107,11 +4102,11 @@
                 "psr/http-client-implementation": "1.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.1",
+                "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "php-http/client-integration-tests": "dev-master#2c025848417c1135031fdf9c728ee53d0a7ceaee as 3.0.999",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.29 || ^9.5.23",
+                "phpunit/phpunit": "^8.5.36 || ^9.6.15",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -4189,7 +4184,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.7.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.8.1"
             },
             "funding": [
                 {
@@ -4205,7 +4200,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-27T10:02:06+00:00"
+            "time": "2023-12-03T20:35:24+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -4292,16 +4287,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.5.1",
+            "version": "2.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "a0b3a03e8e8005257fbc408ce5f0fd0a8274dc7f"
+                "reference": "45b30f99ac27b5ca93cb4831afe16285f57b8221"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/a0b3a03e8e8005257fbc408ce5f0fd0a8274dc7f",
-                "reference": "a0b3a03e8e8005257fbc408ce5f0fd0a8274dc7f",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/45b30f99ac27b5ca93cb4831afe16285f57b8221",
+                "reference": "45b30f99ac27b5ca93cb4831afe16285f57b8221",
                 "shasum": ""
             },
             "require": {
@@ -4315,9 +4310,9 @@
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.1",
+                "bamarni/composer-bin-plugin": "^1.8.2",
                 "http-interop/http-factory-tests": "^0.9",
-                "phpunit/phpunit": "^8.5.29 || ^9.5.23"
+                "phpunit/phpunit": "^8.5.36 || ^9.6.15"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -4388,7 +4383,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.5.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.6.2"
             },
             "funding": [
                 {
@@ -4404,7 +4399,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-03T15:02:42+00:00"
+            "time": "2023-12-03T20:05:35+00:00"
         },
         {
             "name": "koodimonni/composer-dropin-installer",
@@ -6594,16 +6589,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
                 "shasum": ""
             },
             "require": {
@@ -6648,7 +6643,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
             },
             "funding": [
                 {
@@ -6656,7 +6651,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-07T05:35:17+00:00"
+            "time": "2024-03-02T06:30:58+00:00"
         },
         {
             "name": "steverhoades/oauth2-openid-connect-server",
@@ -6705,16 +6700,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.3.12",
+            "version": "v6.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "6f69929b2421cf733a5b791dde3c3a2cfa6340cd"
+                "reference": "0d9e4eb5ad413075624378f474c4167ea202de78"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/6f69929b2421cf733a5b791dde3c3a2cfa6340cd",
-                "reference": "6f69929b2421cf733a5b791dde3c3a2cfa6340cd",
+                "url": "https://api.github.com/repos/symfony/console/zipball/0d9e4eb5ad413075624378f474c4167ea202de78",
+                "reference": "0d9e4eb5ad413075624378f474c4167ea202de78",
                 "shasum": ""
             },
             "require": {
@@ -6722,7 +6717,7 @@
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^5.4|^6.0"
+                "symfony/string": "^5.4|^6.0|^7.0"
             },
             "conflict": {
                 "symfony/dependency-injection": "<5.4",
@@ -6736,12 +6731,16 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/event-dispatcher": "^5.4|^6.0",
-                "symfony/lock": "^5.4|^6.0",
-                "symfony/process": "^5.4|^6.0",
-                "symfony/var-dumper": "^5.4|^6.0"
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/lock": "^5.4|^6.0|^7.0",
+                "symfony/messenger": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.0|^7.0",
+                "symfony/stopwatch": "^5.4|^6.0|^7.0",
+                "symfony/var-dumper": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -6775,7 +6774,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.3.12"
+                "source": "https://github.com/symfony/console/tree/v6.4.4"
             },
             "funding": [
                 {
@@ -6791,20 +6790,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T16:21:43+00:00"
+            "time": "2024-02-22T20:27:10+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v6.3.12",
+            "version": "v6.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "3ca6c70bef0644be86d5acd962f11a6a6aa9382d"
+                "reference": "6236e5e843cb763e9d0f74245678b994afea5363"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/3ca6c70bef0644be86d5acd962f11a6a6aa9382d",
-                "reference": "3ca6c70bef0644be86d5acd962f11a6a6aa9382d",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/6236e5e843cb763e9d0f74245678b994afea5363",
+                "reference": "6236e5e843cb763e9d0f74245678b994afea5363",
                 "shasum": ""
             },
             "require": {
@@ -6812,7 +6811,7 @@
                 "psr/container": "^1.1|^2.0",
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/service-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^6.2.10"
+                "symfony/var-exporter": "^6.2.10|^7.0"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2",
@@ -6826,9 +6825,9 @@
                 "symfony/service-implementation": "1.1|2.0|3.0"
             },
             "require-dev": {
-                "symfony/config": "^6.1",
-                "symfony/expression-language": "^5.4|^6.0",
-                "symfony/yaml": "^5.4|^6.0"
+                "symfony/config": "^6.1|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/yaml": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -6856,7 +6855,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v6.3.12"
+                "source": "https://github.com/symfony/dependency-injection/tree/v6.4.4"
             },
             "funding": [
                 {
@@ -6872,11 +6871,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-30T08:17:33+00:00"
+            "time": "2024-02-22T20:27:10+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.3.0",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
@@ -6923,7 +6922,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.3.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.4.0"
             },
             "funding": [
                 {
@@ -6943,30 +6942,31 @@
         },
         {
             "name": "symfony/error-handler",
-            "version": "v6.3.12",
+            "version": "v6.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "93a8400a7eaaaf385b2d6f71e30e064baa639629"
+                "reference": "c725219bdf2afc59423c32793d5019d2a904e13a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/93a8400a7eaaaf385b2d6f71e30e064baa639629",
-                "reference": "93a8400a7eaaaf385b2d6f71e30e064baa639629",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/c725219bdf2afc59423c32793d5019d2a904e13a",
+                "reference": "c725219bdf2afc59423c32793d5019d2a904e13a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
                 "psr/log": "^1|^2|^3",
-                "symfony/var-dumper": "^5.4|^6.0"
+                "symfony/var-dumper": "^5.4|^6.0|^7.0"
             },
             "conflict": {
-                "symfony/deprecation-contracts": "<2.5"
+                "symfony/deprecation-contracts": "<2.5",
+                "symfony/http-kernel": "<6.4"
             },
             "require-dev": {
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/http-kernel": "^5.4|^6.0",
-                "symfony/serializer": "^5.4|^6.0"
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/serializer": "^5.4|^6.0|^7.0"
             },
             "bin": [
                 "Resources/bin/patch-type-declarations"
@@ -6997,7 +6997,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v6.3.12"
+                "source": "https://github.com/symfony/error-handler/tree/v6.4.4"
             },
             "funding": [
                 {
@@ -7013,20 +7013,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T14:35:58+00:00"
+            "time": "2024-02-22T20:27:10+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v6.3.12",
+            "version": "v6.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "6e344ddd3c18c525b5e5a4e996f3debda48e3078"
+                "reference": "ae9d3a6f3003a6caf56acd7466d8d52378d44fef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/6e344ddd3c18c525b5e5a4e996f3debda48e3078",
-                "reference": "6e344ddd3c18c525b5e5a4e996f3debda48e3078",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/ae9d3a6f3003a6caf56acd7466d8d52378d44fef",
+                "reference": "ae9d3a6f3003a6caf56acd7466d8d52378d44fef",
                 "shasum": ""
             },
             "require": {
@@ -7043,13 +7043,13 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/error-handler": "^5.4|^6.0",
-                "symfony/expression-language": "^5.4|^6.0",
-                "symfony/http-foundation": "^5.4|^6.0",
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/error-handler": "^5.4|^6.0|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^5.4|^6.0|^7.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/stopwatch": "^5.4|^6.0"
+                "symfony/stopwatch": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -7077,7 +7077,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v6.3.12"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v6.4.3"
             },
             "funding": [
                 {
@@ -7093,11 +7093,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T14:35:58+00:00"
+            "time": "2024-01-23T14:51:35+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.3.0",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
@@ -7153,7 +7153,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.3.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.4.0"
             },
             "funding": [
                 {
@@ -7300,16 +7300,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v6.3.12",
+            "version": "v6.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "3b72add708d48e8c08f7152df2d0b8d5303408fa"
+                "reference": "ebc713bc6e6f4b53f46539fc158be85dfcd77304"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/3b72add708d48e8c08f7152df2d0b8d5303408fa",
-                "reference": "3b72add708d48e8c08f7152df2d0b8d5303408fa",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/ebc713bc6e6f4b53f46539fc158be85dfcd77304",
+                "reference": "ebc713bc6e6f4b53f46539fc158be85dfcd77304",
                 "shasum": ""
             },
             "require": {
@@ -7324,12 +7324,12 @@
             "require-dev": {
                 "doctrine/dbal": "^2.13.1|^3|^4",
                 "predis/predis": "^1.1|^2.0",
-                "symfony/cache": "^6.3",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/expression-language": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4.12|^6.0.12|^6.1.4",
-                "symfony/mime": "^5.4|^6.0",
-                "symfony/rate-limiter": "^5.2|^6.0"
+                "symfony/cache": "^6.3|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^5.4.12|^6.0.12|^6.1.4|^7.0",
+                "symfony/mime": "^5.4|^6.0|^7.0",
+                "symfony/rate-limiter": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -7357,7 +7357,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v6.3.12"
+                "source": "https://github.com/symfony/http-foundation/tree/v6.4.4"
             },
             "funding": [
                 {
@@ -7373,29 +7373,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T14:35:58+00:00"
+            "time": "2024-02-08T15:01:18+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v6.3.12",
+            "version": "v6.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "f7d160e46a6e0d3183e7a3846d4e3b4d04d5898b"
+                "reference": "f6947cb939d8efee137797382cb4db1af653ef75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/f7d160e46a6e0d3183e7a3846d4e3b4d04d5898b",
-                "reference": "f7d160e46a6e0d3183e7a3846d4e3b4d04d5898b",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/f6947cb939d8efee137797382cb4db1af653ef75",
+                "reference": "f6947cb939d8efee137797382cb4db1af653ef75",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
                 "psr/log": "^1|^2|^3",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/error-handler": "^6.3",
-                "symfony/event-dispatcher": "^5.4|^6.0",
-                "symfony/http-foundation": "^6.3.4",
+                "symfony/error-handler": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
@@ -7403,7 +7403,7 @@
                 "symfony/cache": "<5.4",
                 "symfony/config": "<6.1",
                 "symfony/console": "<5.4",
-                "symfony/dependency-injection": "<6.3.4",
+                "symfony/dependency-injection": "<6.4",
                 "symfony/doctrine-bridge": "<5.4",
                 "symfony/form": "<5.4",
                 "symfony/http-client": "<5.4",
@@ -7413,7 +7413,7 @@
                 "symfony/translation": "<5.4",
                 "symfony/translation-contracts": "<2.5",
                 "symfony/twig-bridge": "<5.4",
-                "symfony/validator": "<5.4",
+                "symfony/validator": "<6.4",
                 "symfony/var-dumper": "<6.3",
                 "twig/twig": "<2.13"
             },
@@ -7422,26 +7422,26 @@
             },
             "require-dev": {
                 "psr/cache": "^1.0|^2.0|^3.0",
-                "symfony/browser-kit": "^5.4|^6.0",
-                "symfony/clock": "^6.2",
-                "symfony/config": "^6.1",
-                "symfony/console": "^5.4|^6.0",
-                "symfony/css-selector": "^5.4|^6.0",
-                "symfony/dependency-injection": "^6.3.4",
-                "symfony/dom-crawler": "^5.4|^6.0",
-                "symfony/expression-language": "^5.4|^6.0",
-                "symfony/finder": "^5.4|^6.0",
+                "symfony/browser-kit": "^5.4|^6.0|^7.0",
+                "symfony/clock": "^6.2|^7.0",
+                "symfony/config": "^6.1|^7.0",
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/css-selector": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/dom-crawler": "^5.4|^6.0|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/finder": "^5.4|^6.0|^7.0",
                 "symfony/http-client-contracts": "^2.5|^3",
-                "symfony/process": "^5.4|^6.0",
-                "symfony/property-access": "^5.4.5|^6.0.5",
-                "symfony/routing": "^5.4|^6.0",
-                "symfony/serializer": "^6.3",
-                "symfony/stopwatch": "^5.4|^6.0",
-                "symfony/translation": "^5.4|^6.0",
+                "symfony/process": "^5.4|^6.0|^7.0",
+                "symfony/property-access": "^5.4.5|^6.0.5|^7.0",
+                "symfony/routing": "^5.4|^6.0|^7.0",
+                "symfony/serializer": "^6.4.4|^7.0.4",
+                "symfony/stopwatch": "^5.4|^6.0|^7.0",
+                "symfony/translation": "^5.4|^6.0|^7.0",
                 "symfony/translation-contracts": "^2.5|^3",
-                "symfony/uid": "^5.4|^6.0",
-                "symfony/validator": "^6.3",
-                "symfony/var-exporter": "^6.2",
+                "symfony/uid": "^5.4|^6.0|^7.0",
+                "symfony/validator": "^6.4|^7.0",
+                "symfony/var-exporter": "^6.2|^7.0",
                 "twig/twig": "^2.13|^3.0.4"
             },
             "type": "library",
@@ -7470,7 +7470,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v6.3.12"
+                "source": "https://github.com/symfony/http-kernel/tree/v6.4.5"
             },
             "funding": [
                 {
@@ -7486,20 +7486,100 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-30T20:05:26+00:00"
+            "time": "2024-03-04T21:00:47+00:00"
         },
         {
-            "name": "symfony/mime",
-            "version": "v6.3.12",
+            "name": "symfony/mailer",
+            "version": "v6.4.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/mime.git",
-                "reference": "4b24dcaf8dfcd23fb7abb5b9df11e8c8093db68a"
+                "url": "https://github.com/symfony/mailer.git",
+                "reference": "791c5d31a8204cf3db0c66faab70282307f4376b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/4b24dcaf8dfcd23fb7abb5b9df11e8c8093db68a",
-                "reference": "4b24dcaf8dfcd23fb7abb5b9df11e8c8093db68a",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/791c5d31a8204cf3db0c66faab70282307f4376b",
+                "reference": "791c5d31a8204cf3db0c66faab70282307f4376b",
+                "shasum": ""
+            },
+            "require": {
+                "egulias/email-validator": "^2.1.10|^3|^4",
+                "php": ">=8.1",
+                "psr/event-dispatcher": "^1",
+                "psr/log": "^1|^2|^3",
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/mime": "^6.2|^7.0",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/http-client-contracts": "<2.5",
+                "symfony/http-kernel": "<5.4",
+                "symfony/messenger": "<6.2",
+                "symfony/mime": "<6.2",
+                "symfony/twig-bridge": "<6.2.1"
+            },
+            "require-dev": {
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/http-client": "^5.4|^6.0|^7.0",
+                "symfony/messenger": "^6.2|^7.0",
+                "symfony/twig-bridge": "^6.2|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mailer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps sending emails",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/mailer/tree/v6.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-02-03T21:33:47+00:00"
+        },
+        {
+            "name": "symfony/mime",
+            "version": "v6.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mime.git",
+                "reference": "5017e0a9398c77090b7694be46f20eb796262a34"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/5017e0a9398c77090b7694be46f20eb796262a34",
+                "reference": "5017e0a9398c77090b7694be46f20eb796262a34",
                 "shasum": ""
             },
             "require": {
@@ -7513,16 +7593,16 @@
                 "phpdocumentor/reflection-docblock": "<3.2.2",
                 "phpdocumentor/type-resolver": "<1.4.0",
                 "symfony/mailer": "<5.4",
-                "symfony/serializer": "<6.3.12|>=6.4,<6.4.3"
+                "symfony/serializer": "<6.3.2"
             },
             "require-dev": {
                 "egulias/email-validator": "^2.1.10|^3.1|^4",
                 "league/html-to-markdown": "^5.0",
                 "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/property-access": "^5.4|^6.0",
-                "symfony/property-info": "^5.4|^6.0",
-                "symfony/serializer": "~6.3.12|^6.4.3"
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/property-access": "^5.4|^6.0|^7.0",
+                "symfony/property-info": "^5.4|^6.0|^7.0",
+                "symfony/serializer": "^6.3.2|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -7554,7 +7634,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v6.3.12"
+                "source": "https://github.com/symfony/mime/tree/v6.4.3"
             },
             "funding": [
                 {
@@ -7570,20 +7650,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-30T08:17:33+00:00"
+            "time": "2024-01-30T08:32:12+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a"
+                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/5bbc823adecdae860bb64756d639ecfec17b050a",
-                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
+                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
                 "shasum": ""
             },
             "require": {
@@ -7598,7 +7678,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -7636,7 +7716,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -7652,20 +7732,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-iconv",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-iconv.git",
-                "reference": "927013f3aac555983a5059aada98e1907d842695"
+                "reference": "6de50471469b8c9afc38164452ab2b6170ee71c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/927013f3aac555983a5059aada98e1907d842695",
-                "reference": "927013f3aac555983a5059aada98e1907d842695",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/6de50471469b8c9afc38164452ab2b6170ee71c1",
+                "reference": "6de50471469b8c9afc38164452ab2b6170ee71c1",
                 "shasum": ""
             },
             "require": {
@@ -7680,7 +7760,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -7719,7 +7799,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -7735,20 +7815,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "511a08c03c1960e08a883f4cffcacd219b758354"
+                "reference": "875e90aeea2777b6f135677f618529449334a612"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/511a08c03c1960e08a883f4cffcacd219b758354",
-                "reference": "511a08c03c1960e08a883f4cffcacd219b758354",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/875e90aeea2777b6f135677f618529449334a612",
+                "reference": "875e90aeea2777b6f135677f618529449334a612",
                 "shasum": ""
             },
             "require": {
@@ -7760,7 +7840,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -7800,7 +7880,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -7816,20 +7896,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "639084e360537a19f9ee352433b84ce831f3d2da"
+                "reference": "ecaafce9f77234a6a449d29e49267ba10499116d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/639084e360537a19f9ee352433b84ce831f3d2da",
-                "reference": "639084e360537a19f9ee352433b84ce831f3d2da",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/ecaafce9f77234a6a449d29e49267ba10499116d",
+                "reference": "ecaafce9f77234a6a449d29e49267ba10499116d",
                 "shasum": ""
             },
             "require": {
@@ -7843,7 +7923,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -7887,7 +7967,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -7903,20 +7983,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:30:37+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6"
+                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/19bd1e4fcd5b91116f14d8533c57831ed00571b6",
-                "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
+                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
                 "shasum": ""
             },
             "require": {
@@ -7928,7 +8008,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -7971,7 +8051,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -7987,20 +8067,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534"
+                "reference": "42292d99c55abe617799667f454222c54c60e229"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
-                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/42292d99c55abe617799667f454222c54c60e229",
+                "reference": "42292d99c55abe617799667f454222c54c60e229",
                 "shasum": ""
             },
             "require": {
@@ -8015,7 +8095,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -8054,7 +8134,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -8070,7 +8150,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-07-28T09:04:16+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
@@ -8303,16 +8383,16 @@
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "508c652ba3ccf69f8c97f251534f229791b52a57"
+                "reference": "b0f46ebbeeeda3e9d2faebdfbf4b4eae9b59fa11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/508c652ba3ccf69f8c97f251534f229791b52a57",
-                "reference": "508c652ba3ccf69f8c97f251534f229791b52a57",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/b0f46ebbeeeda3e9d2faebdfbf4b4eae9b59fa11",
+                "reference": "b0f46ebbeeeda3e9d2faebdfbf4b4eae9b59fa11",
                 "shasum": ""
             },
             "require": {
@@ -8322,7 +8402,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -8335,7 +8415,10 @@
                 ],
                 "psr-4": {
                     "Symfony\\Polyfill\\Php83\\": ""
-                }
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -8360,7 +8443,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -8376,20 +8459,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-08-16T06:22:46+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v6.3.12",
+            "version": "v6.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "6c5eceb88510fc6ccd7044f2bacb21a3c0993882"
+                "reference": "710e27879e9be3395de2b98da3f52a946039f297"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/6c5eceb88510fc6ccd7044f2bacb21a3c0993882",
-                "reference": "6c5eceb88510fc6ccd7044f2bacb21a3c0993882",
+                "url": "https://api.github.com/repos/symfony/process/zipball/710e27879e9be3395de2b98da3f52a946039f297",
+                "reference": "710e27879e9be3395de2b98da3f52a946039f297",
                 "shasum": ""
             },
             "require": {
@@ -8421,7 +8504,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.3.12"
+                "source": "https://github.com/symfony/process/tree/v6.4.4"
             },
             "funding": [
                 {
@@ -8437,46 +8520,42 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T14:35:58+00:00"
+            "time": "2024-02-20T12:31:00+00:00"
         },
         {
             "name": "symfony/psr-http-message-bridge",
-            "version": "v2.2.0",
+            "version": "v6.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/psr-http-message-bridge.git",
-                "reference": "28a732c05bbad801304ad5a5c674cf2970508993"
+                "reference": "49cfb0223ec64379f7154214dcc1f7c46f3c7a47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/psr-http-message-bridge/zipball/28a732c05bbad801304ad5a5c674cf2970508993",
-                "reference": "28a732c05bbad801304ad5a5c674cf2970508993",
+                "url": "https://api.github.com/repos/symfony/psr-http-message-bridge/zipball/49cfb0223ec64379f7154214dcc1f7c46f3c7a47",
+                "reference": "49cfb0223ec64379f7154214dcc1f7c46f3c7a47",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "psr/http-message": "^1.0 || ^2.0",
-                "symfony/http-foundation": "^5.4 || ^6.0"
+                "php": ">=8.1",
+                "psr/http-message": "^1.0|^2.0",
+                "symfony/http-foundation": "^5.4|^6.0|^7.0"
+            },
+            "conflict": {
+                "php-http/discovery": "<1.15",
+                "symfony/http-kernel": "<6.2"
             },
             "require-dev": {
                 "nyholm/psr7": "^1.1",
-                "psr/log": "^1.1 || ^2 || ^3",
-                "symfony/browser-kit": "^5.4 || ^6.0",
-                "symfony/config": "^5.4 || ^6.0",
-                "symfony/event-dispatcher": "^5.4 || ^6.0",
-                "symfony/framework-bundle": "^5.4 || ^6.0",
-                "symfony/http-kernel": "^5.4 || ^6.0",
-                "symfony/phpunit-bridge": "^6.2"
-            },
-            "suggest": {
-                "nyholm/psr7": "For a super lightweight PSR-7/17 implementation"
+                "php-http/discovery": "^1.15",
+                "psr/log": "^1.1.4|^2|^3",
+                "symfony/browser-kit": "^5.4|^6.0|^7.0",
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/framework-bundle": "^6.2|^7.0",
+                "symfony/http-kernel": "^6.2|^7.0"
             },
             "type": "symfony-bridge",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "2.2-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Bridge\\PsrHttpMessage\\": ""
@@ -8496,11 +8575,11 @@
                 },
                 {
                     "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "PSR HTTP message bridge",
-            "homepage": "http://symfony.com",
+            "homepage": "https://symfony.com",
             "keywords": [
                 "http",
                 "http-message",
@@ -8508,8 +8587,7 @@
                 "psr-7"
             ],
             "support": {
-                "issues": "https://github.com/symfony/psr-http-message-bridge/issues",
-                "source": "https://github.com/symfony/psr-http-message-bridge/tree/v2.2.0"
+                "source": "https://github.com/symfony/psr-http-message-bridge/tree/v6.4.3"
             },
             "funding": [
                 {
@@ -8525,20 +8603,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-21T08:40:19+00:00"
+            "time": "2024-01-23T14:51:35+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v6.3.12",
+            "version": "v6.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "c7a3dcdd44d14022bf0d9d27f14a7b238f7e3e85"
+                "reference": "7fe30068e207d9c31c0138501ab40358eb2d49a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/c7a3dcdd44d14022bf0d9d27f14a7b238f7e3e85",
-                "reference": "c7a3dcdd44d14022bf0d9d27f14a7b238f7e3e85",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/7fe30068e207d9c31c0138501ab40358eb2d49a4",
+                "reference": "7fe30068e207d9c31c0138501ab40358eb2d49a4",
                 "shasum": ""
             },
             "require": {
@@ -8554,11 +8632,11 @@
             "require-dev": {
                 "doctrine/annotations": "^1.12|^2",
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.2",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/expression-language": "^5.4|^6.0",
-                "symfony/http-foundation": "^5.4|^6.0",
-                "symfony/yaml": "^5.4|^6.0"
+                "symfony/config": "^6.2|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^5.4|^6.0|^7.0",
+                "symfony/yaml": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -8592,7 +8670,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v6.3.12"
+                "source": "https://github.com/symfony/routing/tree/v6.4.5"
             },
             "funding": [
                 {
@@ -8608,20 +8686,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-30T13:17:59+00:00"
+            "time": "2024-02-27T12:33:30+00:00"
         },
         {
             "name": "symfony/serializer",
-            "version": "v6.3.12",
+            "version": "v6.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "917d5ecbd6a7aece5b6a33c7aab82ee087d69803"
+                "reference": "88da7f8fe03c5f4c2a69da907f1de03fab2e6872"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/917d5ecbd6a7aece5b6a33c7aab82ee087d69803",
-                "reference": "917d5ecbd6a7aece5b6a33c7aab82ee087d69803",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/88da7f8fe03c5f4c2a69da907f1de03fab2e6872",
+                "reference": "88da7f8fe03c5f4c2a69da907f1de03fab2e6872",
                 "shasum": ""
             },
             "require": {
@@ -8637,28 +8715,32 @@
                 "symfony/property-access": "<5.4",
                 "symfony/property-info": "<5.4.24|>=6,<6.2.11",
                 "symfony/uid": "<5.4",
+                "symfony/validator": "<6.4",
                 "symfony/yaml": "<5.4"
             },
             "require-dev": {
                 "doctrine/annotations": "^1.12|^2",
                 "phpdocumentor/reflection-docblock": "^3.2|^4.0|^5.0",
-                "symfony/cache": "^5.4|^6.0",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/console": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/error-handler": "^5.4|^6.0",
-                "symfony/filesystem": "^5.4|^6.0",
-                "symfony/form": "^5.4|^6.0",
-                "symfony/http-foundation": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4|^6.0",
-                "symfony/mime": "^5.4|^6.0",
-                "symfony/property-access": "^5.4.26|^6.3",
-                "symfony/property-info": "^5.4.24|^6.2.11",
-                "symfony/uid": "^5.4|^6.0",
-                "symfony/validator": "^5.4|^6.0",
-                "symfony/var-dumper": "^5.4|^6.0",
-                "symfony/var-exporter": "^5.4|^6.0",
-                "symfony/yaml": "^5.4|^6.0"
+                "seld/jsonlint": "^1.10",
+                "symfony/cache": "^5.4|^6.0|^7.0",
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/error-handler": "^5.4|^6.0|^7.0",
+                "symfony/filesystem": "^5.4|^6.0|^7.0",
+                "symfony/form": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/messenger": "^5.4|^6.0|^7.0",
+                "symfony/mime": "^5.4|^6.0|^7.0",
+                "symfony/property-access": "^5.4.26|^6.3|^7.0",
+                "symfony/property-info": "^5.4.24|^6.2.11|^7.0",
+                "symfony/translation-contracts": "^2.5|^3",
+                "symfony/uid": "^5.4|^6.0|^7.0",
+                "symfony/validator": "^6.4|^7.0",
+                "symfony/var-dumper": "^5.4|^6.0|^7.0",
+                "symfony/var-exporter": "^5.4|^6.0|^7.0",
+                "symfony/yaml": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -8686,7 +8768,7 @@
             "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/serializer/tree/v6.3.12"
+                "source": "https://github.com/symfony/serializer/tree/v6.4.4"
             },
             "funding": [
                 {
@@ -8702,25 +8784,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-30T08:17:33+00:00"
+            "time": "2024-02-22T20:27:10+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.3.0",
+            "version": "v3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "40da9cc13ec349d9e4966ce18b5fbcd724ab10a4"
+                "reference": "fe07cbc8d837f60caf7018068e350cc5163681a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/40da9cc13ec349d9e4966ce18b5fbcd724ab10a4",
-                "reference": "40da9cc13ec349d9e4966ce18b5fbcd724ab10a4",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/fe07cbc8d837f60caf7018068e350cc5163681a0",
+                "reference": "fe07cbc8d837f60caf7018068e350cc5163681a0",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
-                "psr/container": "^2.0"
+                "psr/container": "^1.1|^2.0"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2"
@@ -8768,7 +8850,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.3.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.4.1"
             },
             "funding": [
                 {
@@ -8784,20 +8866,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-23T14:45:45+00:00"
+            "time": "2023-12-26T14:02:43+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v6.3.12",
+            "version": "v6.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "bce75043af265dc8aca536a6ab1d6b3181763529"
+                "reference": "4e465a95bdc32f49cf4c7f07f751b843bbd6dcd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/bce75043af265dc8aca536a6ab1d6b3181763529",
-                "reference": "bce75043af265dc8aca536a6ab1d6b3181763529",
+                "url": "https://api.github.com/repos/symfony/string/zipball/4e465a95bdc32f49cf4c7f07f751b843bbd6dcd9",
+                "reference": "4e465a95bdc32f49cf4c7f07f751b843bbd6dcd9",
                 "shasum": ""
             },
             "require": {
@@ -8811,11 +8893,11 @@
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/error-handler": "^5.4|^6.0",
-                "symfony/http-client": "^5.4|^6.0",
-                "symfony/intl": "^6.2",
+                "symfony/error-handler": "^5.4|^6.0|^7.0",
+                "symfony/http-client": "^5.4|^6.0|^7.0",
+                "symfony/intl": "^6.2|^7.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^5.4|^6.0"
+                "symfony/var-exporter": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -8854,7 +8936,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.3.12"
+                "source": "https://github.com/symfony/string/tree/v6.4.4"
             },
             "funding": [
                 {
@@ -8870,20 +8952,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T14:35:58+00:00"
+            "time": "2024-02-01T13:16:41+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.3.0",
+            "version": "v3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "02c24deb352fb0d79db5486c0c79905a85e37e86"
+                "reference": "06450585bf65e978026bda220cdebca3f867fde7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/02c24deb352fb0d79db5486c0c79905a85e37e86",
-                "reference": "02c24deb352fb0d79db5486c0c79905a85e37e86",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/06450585bf65e978026bda220cdebca3f867fde7",
+                "reference": "06450585bf65e978026bda220cdebca3f867fde7",
                 "shasum": ""
             },
             "require": {
@@ -8932,7 +9014,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.3.0"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.4.1"
             },
             "funding": [
                 {
@@ -8948,20 +9030,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-30T17:17:10+00:00"
+            "time": "2023-12-26T14:02:43+00:00"
         },
         {
             "name": "symfony/validator",
-            "version": "v6.3.12",
+            "version": "v6.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "5e3ac975cc36d22db979225c587eed3d1f172bb8"
+                "reference": "1cf92edc9a94d16275efef949fa6748d11cc8f47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/5e3ac975cc36d22db979225c587eed3d1f172bb8",
-                "reference": "5e3ac975cc36d22db979225c587eed3d1f172bb8",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/1cf92edc9a94d16275efef949fa6748d11cc8f47",
+                "reference": "1cf92edc9a94d16275efef949fa6748d11cc8f47",
                 "shasum": ""
             },
             "require": {
@@ -8980,27 +9062,27 @@
                 "symfony/http-kernel": "<5.4",
                 "symfony/intl": "<5.4",
                 "symfony/property-info": "<5.4",
-                "symfony/translation": "<5.4.35|>=6.0,<6.3.12|>=6.4,<6.4.3",
+                "symfony/translation": "<5.4.35|>=6.0,<6.3.12|>=6.4,<6.4.3|>=7.0,<7.0.3",
                 "symfony/yaml": "<5.4"
             },
             "require-dev": {
                 "doctrine/annotations": "^1.13|^2",
                 "egulias/email-validator": "^2.1.10|^3|^4",
-                "symfony/cache": "^5.4|^6.0",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/console": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/expression-language": "^5.4|^6.0",
-                "symfony/finder": "^5.4|^6.0",
-                "symfony/http-client": "^5.4|^6.0",
-                "symfony/http-foundation": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4|^6.0",
-                "symfony/intl": "^5.4|^6.0",
-                "symfony/mime": "^5.4|^6.0",
-                "symfony/property-access": "^5.4|^6.0",
-                "symfony/property-info": "^5.4|^6.0",
-                "symfony/translation": "^5.4.35|~6.3.12|^6.4.3",
-                "symfony/yaml": "^5.4|^6.0"
+                "symfony/cache": "^5.4|^6.0|^7.0",
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/finder": "^5.4|^6.0|^7.0",
+                "symfony/http-client": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/intl": "^5.4|^6.0|^7.0",
+                "symfony/mime": "^5.4|^6.0|^7.0",
+                "symfony/property-access": "^5.4|^6.0|^7.0",
+                "symfony/property-info": "^5.4|^6.0|^7.0",
+                "symfony/translation": "^5.4.35|~6.3.12|^6.4.3|^7.0.3",
+                "symfony/yaml": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -9028,7 +9110,7 @@
             "description": "Provides tools to validate values",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/validator/tree/v6.3.12"
+                "source": "https://github.com/symfony/validator/tree/v6.4.4"
             },
             "funding": [
                 {
@@ -9044,20 +9126,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T14:46:07+00:00"
+            "time": "2024-02-22T20:27:10+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v6.3.12",
+            "version": "v6.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "5791cc448c78a1a7879812d8073cc6690286e488"
+                "reference": "b439823f04c98b84d4366c79507e9da6230944b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/5791cc448c78a1a7879812d8073cc6690286e488",
-                "reference": "5791cc448c78a1a7879812d8073cc6690286e488",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/b439823f04c98b84d4366c79507e9da6230944b1",
+                "reference": "b439823f04c98b84d4366c79507e9da6230944b1",
                 "shasum": ""
             },
             "require": {
@@ -9070,10 +9152,11 @@
             },
             "require-dev": {
                 "ext-iconv": "*",
-                "symfony/console": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4|^6.0",
-                "symfony/process": "^5.4|^6.0",
-                "symfony/uid": "^5.4|^6.0",
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/error-handler": "^6.3|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.0|^7.0",
+                "symfony/uid": "^5.4|^6.0|^7.0",
                 "twig/twig": "^2.13|^3.0.4"
             },
             "bin": [
@@ -9112,7 +9195,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v6.3.12"
+                "source": "https://github.com/symfony/var-dumper/tree/v6.4.4"
             },
             "funding": [
                 {
@@ -9128,27 +9211,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T16:21:43+00:00"
+            "time": "2024-02-15T11:23:52+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v6.3.12",
+            "version": "v6.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "ea6fe0e7d188f4b34c28a00d3f9a58ee33801a4b"
+                "reference": "0bd342e24aef49fc82a21bd4eedd3e665d177e5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/ea6fe0e7d188f4b34c28a00d3f9a58ee33801a4b",
-                "reference": "ea6fe0e7d188f4b34c28a00d3f9a58ee33801a4b",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/0bd342e24aef49fc82a21bd4eedd3e665d177e5b",
+                "reference": "0bd342e24aef49fc82a21bd4eedd3e665d177e5b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3"
             },
             "require-dev": {
-                "symfony/var-dumper": "^5.4|^6.0"
+                "symfony/var-dumper": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -9186,7 +9270,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v6.3.12"
+                "source": "https://github.com/symfony/var-exporter/tree/v6.4.4"
             },
             "funding": [
                 {
@@ -9202,20 +9286,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T14:35:58+00:00"
+            "time": "2024-02-26T08:37:45+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.3.12",
+            "version": "v6.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "8ab9bb61e9b862c9b481af745ff163bc5e5e6246"
+                "reference": "d75715985f0f94f978e3a8fa42533e10db921b90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/8ab9bb61e9b862c9b481af745ff163bc5e5e6246",
-                "reference": "8ab9bb61e9b862c9b481af745ff163bc5e5e6246",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/d75715985f0f94f978e3a8fa42533e10db921b90",
+                "reference": "d75715985f0f94f978e3a8fa42533e10db921b90",
                 "shasum": ""
             },
             "require": {
@@ -9227,7 +9311,7 @@
                 "symfony/console": "<5.4"
             },
             "require-dev": {
-                "symfony/console": "^5.4|^6.0"
+                "symfony/console": "^5.4|^6.0|^7.0"
             },
             "bin": [
                 "Resources/bin/yaml-lint"
@@ -9258,7 +9342,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.3.12"
+                "source": "https://github.com/symfony/yaml/tree/v6.4.3"
             },
             "funding": [
                 {
@@ -9274,30 +9358,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T14:35:58+00:00"
+            "time": "2024-01-23T14:51:35+00:00"
         },
         {
             "name": "twig/twig",
-            "version": "v3.6.1",
+            "version": "v3.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "7e7d5839d4bec168dfeef0ac66d5c5a2edbabffd"
+                "reference": "9d15f0ac07f44dc4217883ec6ae02fd555c6f71d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/7e7d5839d4bec168dfeef0ac66d5c5a2edbabffd",
-                "reference": "7e7d5839d4bec168dfeef0ac66d5c5a2edbabffd",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/9d15f0ac07f44dc4217883ec6ae02fd555c6f71d",
+                "reference": "9d15f0ac07f44dc4217883ec6ae02fd555c6f71d",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
                 "symfony/polyfill-ctype": "^1.8",
-                "symfony/polyfill-mbstring": "^1.3"
+                "symfony/polyfill-mbstring": "^1.3",
+                "symfony/polyfill-php80": "^1.22"
             },
             "require-dev": {
                 "psr/container": "^1.0|^2.0",
-                "symfony/phpunit-bridge": "^4.4.9|^5.0.9|^6.0"
+                "symfony/phpunit-bridge": "^5.4.9|^6.3|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -9333,7 +9418,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.6.1"
+                "source": "https://github.com/twigphp/Twig/tree/v3.8.0"
             },
             "funding": [
                 {
@@ -9345,7 +9430,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-08T12:52:13+00:00"
+            "time": "2023-11-21T18:54:41+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -10434,16 +10519,16 @@
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "b66d11b7479109ab547f9405b97205640b17d385"
+                "reference": "3ce240142f6d59b808dd65c1f52f7a1c252e6cfd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/b66d11b7479109ab547f9405b97205640b17d385",
-                "reference": "b66d11b7479109ab547f9405b97205640b17d385",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/3ce240142f6d59b808dd65c1f52f7a1c252e6cfd",
+                "reference": "3ce240142f6d59b808dd65c1f52f7a1c252e6cfd",
                 "shasum": ""
             },
             "require": {
@@ -10490,7 +10575,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.4.0"
+                "source": "https://github.com/composer/ca-bundle/tree/1.4.1"
             },
             "funding": [
                 {
@@ -10506,7 +10591,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-18T12:05:55+00:00"
+            "time": "2024-02-23T10:16:52+00:00"
         },
         {
             "name": "composer/class-map-generator",
@@ -11171,16 +11256,16 @@
         },
         {
             "name": "doctrine/collections",
-            "version": "2.1.4",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/collections.git",
-                "reference": "72328a11443a0de79967104ad36ba7b30bded134"
+                "reference": "420480fc085bc65f3c956af13abe8e7546f94813"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/collections/zipball/72328a11443a0de79967104ad36ba7b30bded134",
-                "reference": "72328a11443a0de79967104ad36ba7b30bded134",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/420480fc085bc65f3c956af13abe8e7546f94813",
+                "reference": "420480fc085bc65f3c956af13abe8e7546f94813",
                 "shasum": ""
             },
             "require": {
@@ -11192,7 +11277,7 @@
                 "ext-json": "*",
                 "phpstan/phpstan": "^1.8",
                 "phpstan/phpstan-phpunit": "^1.0",
-                "phpunit/phpunit": "^9.5",
+                "phpunit/phpunit": "^10.5",
                 "vimeo/psalm": "^5.11"
             },
             "type": "library",
@@ -11237,7 +11322,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/collections/issues",
-                "source": "https://github.com/doctrine/collections/tree/2.1.4"
+                "source": "https://github.com/doctrine/collections/tree/2.2.1"
             },
             "funding": [
                 {
@@ -11253,7 +11338,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-03T09:22:33+00:00"
+            "time": "2024-03-05T22:28:45+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -11327,16 +11412,16 @@
         },
         {
             "name": "drupal/coder",
-            "version": "8.3.22",
+            "version": "8.3.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pfrenssen/coder.git",
-                "reference": "ba6e62303d567863275fb086941f50a06dc7d08f"
+                "reference": "1a1613d83c08dac5be593f2775c9eccae1b41805"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pfrenssen/coder/zipball/ba6e62303d567863275fb086941f50a06dc7d08f",
-                "reference": "ba6e62303d567863275fb086941f50a06dc7d08f",
+                "url": "https://api.github.com/repos/pfrenssen/coder/zipball/1a1613d83c08dac5be593f2775c9eccae1b41805",
+                "reference": "1a1613d83c08dac5be593f2775c9eccae1b41805",
                 "shasum": ""
             },
             "require": {
@@ -11374,20 +11459,20 @@
                 "issues": "https://www.drupal.org/project/issues/coder",
                 "source": "https://www.drupal.org/project/coder"
             },
-            "time": "2023-10-15T09:55:50+00:00"
+            "time": "2024-01-27T18:13:12+00:00"
         },
         {
             "name": "drupal/core-dev",
-            "version": "10.1.8",
+            "version": "10.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-dev.git",
-                "reference": "5d02df4f05f5033e7d8bf4098efa55cc0847e2b9"
+                "reference": "71d714deff8c277b8ef2f331f3bddbba03274dc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core-dev/zipball/5d02df4f05f5033e7d8bf4098efa55cc0847e2b9",
-                "reference": "5d02df4f05f5033e7d8bf4098efa55cc0847e2b9",
+                "url": "https://api.github.com/repos/drupal/core-dev/zipball/71d714deff8c277b8ef2f331f3bddbba03274dc1",
+                "reference": "71d714deff8c277b8ef2f331f3bddbba03274dc1",
                 "shasum": ""
             },
             "require": {
@@ -11395,26 +11480,28 @@
                 "behat/mink-browserkit-driver": "^2.1",
                 "behat/mink-selenium2-driver": "^1.4",
                 "colinodell/psr-testlogger": "^1.2",
-                "composer/composer": "^2.6.4",
+                "composer/composer": "^2.7",
                 "drupal/coder": "^8.3.10",
                 "instaclick/php-webdriver": "^1.4.1",
                 "justinrainbow/json-schema": "^5.2",
-                "mglaman/phpstan-drupal": "^1.1.34",
+                "mglaman/phpstan-drupal": "^1.2.1",
+                "micheh/phpcs-gitlab": "^1.1",
                 "mikey179/vfsstream": "^1.6.11",
+                "open-telemetry/exporter-otlp": "^1",
+                "open-telemetry/sdk": "^1",
+                "php-http/guzzle7-adapter": "^1.0",
                 "phpspec/prophecy-phpunit": "^2",
                 "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^1.10.1",
+                "phpstan/phpstan": "^1.10.47",
                 "phpstan/phpstan-phpunit": "^1.3.11",
-                "phpunit/phpunit": "^9.5",
-                "symfony/browser-kit": "^6.3",
-                "symfony/css-selector": "^6.3",
-                "symfony/dom-crawler": "^6.3",
-                "symfony/error-handler": "^6.3",
-                "symfony/filesystem": "^6.3",
-                "symfony/finder": "^6.3",
-                "symfony/lock": "^6.3",
-                "symfony/phpunit-bridge": "^6.3",
-                "symfony/var-dumper": "^6.3"
+                "phpunit/phpunit": "^9.6.13",
+                "symfony/browser-kit": "^6.4",
+                "symfony/css-selector": "^6.4",
+                "symfony/dom-crawler": "^6.4",
+                "symfony/error-handler": "^6.4",
+                "symfony/lock": "^6.4",
+                "symfony/phpunit-bridge": "^6.4",
+                "symfony/var-dumper": "^6.4"
             },
             "conflict": {
                 "webflo/drupal-core-require-dev": "*"
@@ -11426,9 +11513,9 @@
             ],
             "description": "require-dev dependencies from drupal/drupal; use in addition to drupal/core-recommended to run tests from drupal/core.",
             "support": {
-                "source": "https://github.com/drupal/core-dev/tree/10.1.8"
+                "source": "https://github.com/drupal/core-dev/tree/10.2.4"
             },
-            "time": "2023-10-05T21:10:12+00:00"
+            "time": "2024-02-14T18:07:20+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -11601,6 +11688,50 @@
                 }
             ],
             "time": "2023-12-20T13:02:08+00:00"
+        },
+        {
+            "name": "google/protobuf",
+            "version": "v3.25.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/protocolbuffers/protobuf-php.git",
+                "reference": "983a87f4f8798a90ca3a25b0f300b8fda38df643"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/983a87f4f8798a90ca3a25b0f300b8fda38df643",
+                "reference": "983a87f4f8798a90ca3a25b0f300b8fda38df643",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=5.0.0"
+            },
+            "suggest": {
+                "ext-bcmath": "Need to support JSON deserialization"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Google\\Protobuf\\": "src/Google/Protobuf",
+                    "GPBMetadata\\Google\\Protobuf\\": "src/GPBMetadata/Google/Protobuf"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "proto library for PHP",
+            "homepage": "https://developers.google.com/protocol-buffers/",
+            "keywords": [
+                "proto"
+            ],
+            "support": {
+                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v3.25.3"
+            },
+            "time": "2024-02-15T21:11:49+00:00"
         },
         {
             "name": "instaclick/php-webdriver",
@@ -11797,16 +11928,16 @@
         },
         {
             "name": "mglaman/phpstan-drupal",
-            "version": "1.2.6",
+            "version": "1.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mglaman/phpstan-drupal.git",
-                "reference": "ba8678f8cbea42cc41022c21751004eb677cf5a4"
+                "reference": "32f79fcf48c74532014248687ae3850581a22416"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mglaman/phpstan-drupal/zipball/ba8678f8cbea42cc41022c21751004eb677cf5a4",
-                "reference": "ba8678f8cbea42cc41022c21751004eb677cf5a4",
+                "url": "https://api.github.com/repos/mglaman/phpstan-drupal/zipball/32f79fcf48c74532014248687ae3850581a22416",
+                "reference": "32f79fcf48c74532014248687ae3850581a22416",
                 "shasum": ""
             },
             "require": {
@@ -11881,7 +12012,7 @@
             "description": "Drupal extension and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/mglaman/phpstan-drupal/issues",
-                "source": "https://github.com/mglaman/phpstan-drupal/tree/1.2.6"
+                "source": "https://github.com/mglaman/phpstan-drupal/tree/1.2.7"
             },
             "funding": [
                 {
@@ -11897,7 +12028,59 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-16T00:42:10+00:00"
+            "time": "2024-02-14T04:38:08+00:00"
+        },
+        {
+            "name": "micheh/phpcs-gitlab",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/micheh/phpcs-gitlab.git",
+                "reference": "fd64e6579d9e30a82abba616fabcb9a2c837c7a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/micheh/phpcs-gitlab/zipball/fd64e6579d9e30a82abba616fabcb9a2c837c7a8",
+                "reference": "fd64e6579d9e30a82abba616fabcb9a2c837c7a8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.0 || ^9.0",
+                "squizlabs/php_codesniffer": "^3.3.1",
+                "vimeo/psalm": "^4.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Micheh\\PhpCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Michel Hunziker",
+                    "email": "info@michelhunziker.com"
+                }
+            ],
+            "description": "Gitlab Report for PHP_CodeSniffer (display the violations in the Gitlab CI/CD Code Quality Report)",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "code quality",
+                "gitlab",
+                "phpcs",
+                "report"
+            ],
+            "support": {
+                "issues": "https://github.com/micheh/phpcs-gitlab/issues",
+                "source": "https://github.com/micheh/phpcs-gitlab/tree/1.1.0"
+            },
+            "time": "2020-12-20T09:39:07+00:00"
         },
         {
             "name": "mikey179/vfsstream",
@@ -12292,6 +12475,401 @@
             "time": "2021-04-14T09:16:52+00:00"
         },
         {
+            "name": "open-telemetry/api",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opentelemetry-php/api.git",
+                "reference": "87de95d926f46262885d0d390060c095af13e2e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opentelemetry-php/api/zipball/87de95d926f46262885d0d390060c095af13e2e5",
+                "reference": "87de95d926f46262885d0d390060c095af13e2e5",
+                "shasum": ""
+            },
+            "require": {
+                "open-telemetry/context": "^1.0",
+                "php": "^7.4 || ^8.0",
+                "psr/log": "^1.1|^2.0|^3.0",
+                "symfony/polyfill-php80": "^1.26",
+                "symfony/polyfill-php81": "^1.26",
+                "symfony/polyfill-php82": "^1.26"
+            },
+            "conflict": {
+                "open-telemetry/sdk": "<=1.0.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Trace/functions.php"
+                ],
+                "psr-4": {
+                    "OpenTelemetry\\API\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "opentelemetry-php contributors",
+                    "homepage": "https://github.com/open-telemetry/opentelemetry-php/graphs/contributors"
+                }
+            ],
+            "description": "API for OpenTelemetry PHP.",
+            "keywords": [
+                "Metrics",
+                "api",
+                "apm",
+                "logging",
+                "opentelemetry",
+                "otel",
+                "tracing"
+            ],
+            "support": {
+                "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V",
+                "docs": "https://opentelemetry.io/docs/php",
+                "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
+                "source": "https://github.com/open-telemetry/opentelemetry-php"
+            },
+            "time": "2024-02-06T01:32:25+00:00"
+        },
+        {
+            "name": "open-telemetry/context",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opentelemetry-php/context.git",
+                "reference": "e9d254a7c89885e63fd2fde54e31e81aaaf52b7c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opentelemetry-php/context/zipball/e9d254a7c89885e63fd2fde54e31e81aaaf52b7c",
+                "reference": "e9d254a7c89885e63fd2fde54e31e81aaaf52b7c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "symfony/polyfill-php80": "^1.26",
+                "symfony/polyfill-php81": "^1.26",
+                "symfony/polyfill-php82": "^1.26"
+            },
+            "suggest": {
+                "ext-ffi": "To allow context switching in Fibers"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "fiber/initialize_fiber_handler.php"
+                ],
+                "psr-4": {
+                    "OpenTelemetry\\Context\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "opentelemetry-php contributors",
+                    "homepage": "https://github.com/open-telemetry/opentelemetry-php/graphs/contributors"
+                }
+            ],
+            "description": "Context implementation for OpenTelemetry PHP.",
+            "keywords": [
+                "Context",
+                "opentelemetry",
+                "otel"
+            ],
+            "support": {
+                "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V",
+                "docs": "https://opentelemetry.io/docs/php",
+                "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
+                "source": "https://github.com/open-telemetry/opentelemetry-php"
+            },
+            "time": "2024-01-13T05:50:44+00:00"
+        },
+        {
+            "name": "open-telemetry/exporter-otlp",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opentelemetry-php/exporter-otlp.git",
+                "reference": "342686bfce05867b56561a0af2fc8a4a8f27b3cc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opentelemetry-php/exporter-otlp/zipball/342686bfce05867b56561a0af2fc8a4a8f27b3cc",
+                "reference": "342686bfce05867b56561a0af2fc8a4a8f27b3cc",
+                "shasum": ""
+            },
+            "require": {
+                "open-telemetry/api": "^1.0",
+                "open-telemetry/gen-otlp-protobuf": "^1.1",
+                "open-telemetry/sdk": "^1.0",
+                "php": "^7.4 || ^8.0",
+                "php-http/discovery": "^1.14"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "_register.php"
+                ],
+                "psr-4": {
+                    "OpenTelemetry\\Contrib\\Otlp\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "opentelemetry-php contributors",
+                    "homepage": "https://github.com/open-telemetry/opentelemetry-php/graphs/contributors"
+                }
+            ],
+            "description": "OTLP exporter for OpenTelemetry.",
+            "keywords": [
+                "Metrics",
+                "exporter",
+                "gRPC",
+                "http",
+                "opentelemetry",
+                "otel",
+                "otlp",
+                "tracing"
+            ],
+            "support": {
+                "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V",
+                "docs": "https://opentelemetry.io/docs/php",
+                "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
+                "source": "https://github.com/open-telemetry/opentelemetry-php"
+            },
+            "time": "2024-02-28T21:57:02+00:00"
+        },
+        {
+            "name": "open-telemetry/gen-otlp-protobuf",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opentelemetry-php/gen-otlp-protobuf.git",
+                "reference": "76e2a44357f8c3fdcabcb070ec8a59e52ae3e3c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opentelemetry-php/gen-otlp-protobuf/zipball/76e2a44357f8c3fdcabcb070ec8a59e52ae3e3c3",
+                "reference": "76e2a44357f8c3fdcabcb070ec8a59e52ae3e3c3",
+                "shasum": ""
+            },
+            "require": {
+                "google/protobuf": "^3.3.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "suggest": {
+                "ext-protobuf": "For better performance, when dealing with the protobuf format"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opentelemetry\\Proto\\": "Opentelemetry/Proto/",
+                    "GPBMetadata\\Opentelemetry\\": "GPBMetadata/Opentelemetry/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "opentelemetry-php contributors",
+                    "homepage": "https://github.com/open-telemetry/opentelemetry-php/graphs/contributors"
+                }
+            ],
+            "description": "PHP protobuf files for communication with OpenTelemetry OTLP collectors/servers.",
+            "keywords": [
+                "Metrics",
+                "apm",
+                "gRPC",
+                "logging",
+                "opentelemetry",
+                "otel",
+                "otlp",
+                "protobuf",
+                "tracing"
+            ],
+            "support": {
+                "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V",
+                "docs": "https://opentelemetry.io/docs/php",
+                "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
+                "source": "https://github.com/open-telemetry/opentelemetry-php"
+            },
+            "time": "2024-01-16T21:54:57+00:00"
+        },
+        {
+            "name": "open-telemetry/sdk",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opentelemetry-php/sdk.git",
+                "reference": "1da4c0ca4f1a3c0fe84b81729dadec16f464fa77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opentelemetry-php/sdk/zipball/1da4c0ca4f1a3c0fe84b81729dadec16f464fa77",
+                "reference": "1da4c0ca4f1a3c0fe84b81729dadec16f464fa77",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "open-telemetry/api": "^1.0",
+                "open-telemetry/context": "^1.0",
+                "open-telemetry/sem-conv": "^1.0",
+                "php": "^7.4 || ^8.0",
+                "php-http/discovery": "^1.14",
+                "psr/http-client": "^1.0",
+                "psr/http-client-implementation": "^1.0",
+                "psr/http-factory-implementation": "^1.0",
+                "psr/http-message": "^1.0.1|^2.0",
+                "psr/log": "^1.1|^2.0|^3.0",
+                "symfony/polyfill-mbstring": "^1.23",
+                "symfony/polyfill-php80": "^1.26",
+                "symfony/polyfill-php81": "^1.26",
+                "symfony/polyfill-php82": "^1.26"
+            },
+            "suggest": {
+                "ext-gmp": "To support unlimited number of synchronous metric readers",
+                "ext-mbstring": "To increase performance of string operations"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Common/Util/functions.php",
+                    "Logs/Exporter/_register.php",
+                    "Metrics/MetricExporter/_register.php",
+                    "Propagation/_register.php",
+                    "Trace/SpanExporter/_register.php",
+                    "Common/Dev/Compatibility/_load.php",
+                    "_autoload.php"
+                ],
+                "psr-4": {
+                    "OpenTelemetry\\SDK\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "opentelemetry-php contributors",
+                    "homepage": "https://github.com/open-telemetry/opentelemetry-php/graphs/contributors"
+                }
+            ],
+            "description": "SDK for OpenTelemetry PHP.",
+            "keywords": [
+                "Metrics",
+                "apm",
+                "logging",
+                "opentelemetry",
+                "otel",
+                "sdk",
+                "tracing"
+            ],
+            "support": {
+                "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V",
+                "docs": "https://opentelemetry.io/docs/php",
+                "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
+                "source": "https://github.com/open-telemetry/opentelemetry-php"
+            },
+            "time": "2024-02-02T03:42:40+00:00"
+        },
+        {
+            "name": "open-telemetry/sem-conv",
+            "version": "1.24.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opentelemetry-php/sem-conv.git",
+                "reference": "d03e6501d21c04cd1b1e66e4cbcc7c2dd2e2cfa3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opentelemetry-php/sem-conv/zipball/d03e6501d21c04cd1b1e66e4cbcc7c2dd2e2cfa3",
+                "reference": "d03e6501d21c04cd1b1e66e4cbcc7c2dd2e2cfa3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "OpenTelemetry\\SemConv\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "opentelemetry-php contributors",
+                    "homepage": "https://github.com/open-telemetry/opentelemetry-php/graphs/contributors"
+                }
+            ],
+            "description": "Semantic conventions for OpenTelemetry PHP.",
+            "keywords": [
+                "Metrics",
+                "apm",
+                "logging",
+                "opentelemetry",
+                "otel",
+                "semantic conventions",
+                "semconv",
+                "tracing"
+            ],
+            "support": {
+                "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V",
+                "docs": "https://opentelemetry.io/docs/php",
+                "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
+                "source": "https://github.com/open-telemetry/opentelemetry-php"
+            },
+            "time": "2024-01-23T21:47:17+00:00"
+        },
+        {
             "name": "openlss/lib-array2xml",
             "version": "1.0.0",
             "source": {
@@ -12346,20 +12924,21 @@
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-phar": "*",
                 "ext-xmlwriter": "*",
                 "phar-io/version": "^3.0.1",
@@ -12400,9 +12979,15 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
             },
-            "time": "2021-07-20T11:28:43+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
         },
         {
             "name": "phar-io/version",
@@ -12495,6 +13080,68 @@
                 "source": "https://github.com/FloeDesignTechnologies/phpcs-security-audit/tree/master"
             },
             "time": "2019-08-05T19:34:55+00:00"
+        },
+        {
+            "name": "php-http/guzzle7-adapter",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/guzzle7-adapter.git",
+                "reference": "fb075a71dbfa4847cf0c2938c4e5a9c478ef8b01"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/guzzle7-adapter/zipball/fb075a71dbfa4847cf0c2938c4e5a9c478ef8b01",
+                "reference": "fb075a71dbfa4847cf0c2938c4e5a9c478ef8b01",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^7.0",
+                "php": "^7.2 | ^8.0",
+                "php-http/httplug": "^2.0",
+                "psr/http-client": "^1.0"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "1.0",
+                "php-http/client-implementation": "1.0",
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "php-http/client-integration-tests": "^3.0",
+                "phpunit/phpunit": "^8.0|^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Adapter\\Guzzle7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com"
+                }
+            ],
+            "description": "Guzzle 7 HTTP Adapter",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "Guzzle",
+                "http"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/guzzle7-adapter/issues",
+                "source": "https://github.com/php-http/guzzle7-adapter/tree/1.0.0"
+            },
+            "time": "2021-03-09T07:35:15+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -12670,21 +13317,21 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.8.0",
+            "version": "1.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "fad452781b3d774e3337b0c0b245dd8e5a4455fc"
+                "reference": "153ae662783729388a584b4361f2545e4d841e3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/fad452781b3d774e3337b0c0b245dd8e5a4455fc",
-                "reference": "fad452781b3d774e3337b0c0b245dd8e5a4455fc",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/153ae662783729388a584b4361f2545e4d841e3c",
+                "reference": "153ae662783729388a584b4361f2545e4d841e3c",
                 "shasum": ""
             },
             "require": {
                 "doctrine/deprecations": "^1.0",
-                "php": "^7.4 || ^8.0",
+                "php": "^7.3 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.0",
                 "phpstan/phpdoc-parser": "^1.13"
             },
@@ -12722,9 +13369,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.8.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.8.2"
             },
-            "time": "2024-01-11T11:49:22+00:00"
+            "time": "2024-02-23T11:10:43+00:00"
         },
         {
             "name": "phpro/grumphp",
@@ -12846,24 +13493,24 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.18.0",
+            "version": "v1.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "d4f454f7e1193933f04e6500de3e79191648ed0c"
+                "reference": "67a759e7d8746d501c41536ba40cd9c0a07d6a87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d4f454f7e1193933f04e6500de3e79191648ed0c",
-                "reference": "d4f454f7e1193933f04e6500de3e79191648ed0c",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/67a759e7d8746d501c41536ba40cd9c0a07d6a87",
+                "reference": "67a759e7d8746d501c41536ba40cd9c0a07d6a87",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2 || ^2.0",
                 "php": "^7.2 || 8.0.* || 8.1.* || 8.2.* || 8.3.*",
                 "phpdocumentor/reflection-docblock": "^5.2",
-                "sebastian/comparator": "^3.0 || ^4.0 || ^5.0",
-                "sebastian/recursion-context": "^3.0 || ^4.0 || ^5.0"
+                "sebastian/comparator": "^3.0 || ^4.0 || ^5.0 || ^6.0",
+                "sebastian/recursion-context": "^3.0 || ^4.0 || ^5.0 || ^6.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^6.0 || ^7.0",
@@ -12909,33 +13556,33 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/v1.18.0"
+                "source": "https://github.com/phpspec/prophecy/tree/v1.19.0"
             },
-            "time": "2023-12-07T16:22:33+00:00"
+            "time": "2024-02-29T11:52:51+00:00"
         },
         {
             "name": "phpspec/prophecy-phpunit",
-            "version": "v2.1.0",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy-phpunit.git",
-                "reference": "29f8114c2c319a4308e6b070902211e062efa392"
+                "reference": "16e1247e139434bce0bac09848bc5c8d882940fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy-phpunit/zipball/29f8114c2c319a4308e6b070902211e062efa392",
-                "reference": "29f8114c2c319a4308e6b070902211e062efa392",
+                "url": "https://api.github.com/repos/phpspec/prophecy-phpunit/zipball/16e1247e139434bce0bac09848bc5c8d882940fc",
+                "reference": "16e1247e139434bce0bac09848bc5c8d882940fc",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.3 || ^8",
                 "phpspec/prophecy": "^1.18",
-                "phpunit/phpunit": "^9.1 || ^10.1"
+                "phpunit/phpunit": "^9.1 || ^10.1 || ^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "2.x-dev"
                 }
             },
             "autoload": {
@@ -12961,9 +13608,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy-phpunit/issues",
-                "source": "https://github.com/phpspec/prophecy-phpunit/tree/v2.1.0"
+                "source": "https://github.com/phpspec/prophecy-phpunit/tree/v2.2.0"
             },
-            "time": "2023-12-08T12:48:02+00:00"
+            "time": "2024-03-01T08:33:58+00:00"
         },
         {
             "name": "phpstan/extension-installer",
@@ -13011,16 +13658,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.25.0",
+            "version": "1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "bd84b629c8de41aa2ae82c067c955e06f1b00240"
+                "reference": "231e3186624c03d7e7c890ec662b81e6b0405227"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/bd84b629c8de41aa2ae82c067c955e06f1b00240",
-                "reference": "bd84b629c8de41aa2ae82c067c955e06f1b00240",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/231e3186624c03d7e7c890ec662b81e6b0405227",
+                "reference": "231e3186624c03d7e7c890ec662b81e6b0405227",
                 "shasum": ""
             },
             "require": {
@@ -13052,22 +13699,22 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.25.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.26.0"
             },
-            "time": "2024-01-04T17:06:16+00:00"
+            "time": "2024-02-23T16:05:55+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.57",
+            "version": "1.10.59",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "1627b1d03446904aaa77593f370c5201d2ecc34e"
+                "reference": "e607609388d3a6d418a50a49f7940e8086798281"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1627b1d03446904aaa77593f370c5201d2ecc34e",
-                "reference": "1627b1d03446904aaa77593f370c5201d2ecc34e",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e607609388d3a6d418a50a49f7940e8086798281",
+                "reference": "e607609388d3a6d418a50a49f7940e8086798281",
                 "shasum": ""
             },
             "require": {
@@ -13116,7 +13763,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-24T11:51:34+00:00"
+            "time": "2024-02-20T13:59:13+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
@@ -13168,16 +13815,16 @@
         },
         {
             "name": "phpstan/phpstan-phpunit",
-            "version": "1.3.15",
+            "version": "1.3.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-phpunit.git",
-                "reference": "70ecacc64fe8090d8d2a33db5a51fe8e88acd93a"
+                "reference": "d5242a59d035e46774f2e634b374bc39ff62cb95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/70ecacc64fe8090d8d2a33db5a51fe8e88acd93a",
-                "reference": "70ecacc64fe8090d8d2a33db5a51fe8e88acd93a",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/d5242a59d035e46774f2e634b374bc39ff62cb95",
+                "reference": "d5242a59d035e46774f2e634b374bc39ff62cb95",
                 "shasum": ""
             },
             "require": {
@@ -13214,22 +13861,22 @@
             "description": "PHPUnit extensions and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
-                "source": "https://github.com/phpstan/phpstan-phpunit/tree/1.3.15"
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/1.3.16"
             },
-            "time": "2023-10-09T18:58:39+00:00"
+            "time": "2024-02-23T09:51:20+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.30",
+            "version": "9.2.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089"
+                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ca2bd87d2f9215904682a9cb9bb37dda98e76089",
-                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/48c34b5d8d983006bd2adc2d0de92963b9155965",
+                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965",
                 "shasum": ""
             },
             "require": {
@@ -13286,7 +13933,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.30"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.31"
             },
             "funding": [
                 {
@@ -13294,7 +13941,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:47:57+00:00"
+            "time": "2024-03-02T06:37:42+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -13539,16 +14186,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.16",
+            "version": "9.6.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3767b2c56ce02d01e3491046f33466a1ae60a37f"
+                "reference": "1a156980d78a6666721b7e8e8502fe210b587fcd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3767b2c56ce02d01e3491046f33466a1ae60a37f",
-                "reference": "3767b2c56ce02d01e3491046f33466a1ae60a37f",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1a156980d78a6666721b7e8e8502fe210b587fcd",
+                "reference": "1a156980d78a6666721b7e8e8502fe210b587fcd",
                 "shasum": ""
             },
             "require": {
@@ -13622,7 +14269,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.16"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.17"
             },
             "funding": [
                 {
@@ -13638,7 +14285,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-19T07:03:14+00:00"
+            "time": "2024-02-23T13:14:51+00:00"
         },
         {
             "name": "react/promise",
@@ -13715,16 +14362,16 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
                 "shasum": ""
             },
             "require": {
@@ -13759,7 +14406,7 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
             },
             "funding": [
                 {
@@ -13767,7 +14414,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:08:49+00:00"
+            "time": "2024-03-02T06:27:43+00:00"
         },
         {
             "name": "sebastian/code-unit",
@@ -14076,16 +14723,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
+                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/78c00df8f170e02473b682df15bfcdacc3d32d72",
+                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72",
                 "shasum": ""
             },
             "require": {
@@ -14141,7 +14788,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.6"
             },
             "funding": [
                 {
@@ -14149,20 +14796,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T06:03:37+00:00"
+            "time": "2024-03-02T06:33:00+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.6",
+            "version": "5.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bde739e7565280bda77be70044ac1047bc007e34"
+                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bde739e7565280bda77be70044ac1047bc007e34",
-                "reference": "bde739e7565280bda77be70044ac1047bc007e34",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
+                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
                 "shasum": ""
             },
             "require": {
@@ -14205,7 +14852,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.6"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.7"
             },
             "funding": [
                 {
@@ -14213,7 +14860,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-02T09:26:13+00:00"
+            "time": "2024-03-02T06:35:11+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -14909,16 +15556,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.8.1",
+            "version": "3.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7"
+                "reference": "d63cee4890a8afaf86a22e51ad4d97c91dd4579b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/14f5fff1e64118595db5408e946f3a22c75807f7",
-                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/d63cee4890a8afaf86a22e51ad4d97c91dd4579b",
+                "reference": "d63cee4890a8afaf86a22e51ad4d97c91dd4579b",
                 "shasum": ""
             },
             "require": {
@@ -14985,7 +15632,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-01-11T20:47:48+00:00"
+            "time": "2024-02-16T15:06:51+00:00"
         },
         {
             "name": "symfony/browser-kit",
@@ -15197,16 +15844,16 @@
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v6.4.3",
+            "version": "v6.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "6db31849011fefe091e94d0bb10cba26f7919894"
+                "reference": "f0e7ec3fa17000e2d0cb4557b4b47c88a6a63531"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/6db31849011fefe091e94d0bb10cba26f7919894",
-                "reference": "6db31849011fefe091e94d0bb10cba26f7919894",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/f0e7ec3fa17000e2d0cb4557b4b47c88a6a63531",
+                "reference": "f0e7ec3fa17000e2d0cb4557b4b47c88a6a63531",
                 "shasum": ""
             },
             "require": {
@@ -15244,7 +15891,7 @@
             "description": "Eases DOM navigation for HTML and XML documents",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dom-crawler/tree/v6.4.3"
+                "source": "https://github.com/symfony/dom-crawler/tree/v6.4.4"
             },
             "funding": [
                 {
@@ -15260,7 +15907,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T14:51:35+00:00"
+            "time": "2024-02-07T09:17:57+00:00"
         },
         {
             "name": "symfony/dotenv",
@@ -15484,16 +16131,16 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v6.4.3",
+            "version": "v6.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "d49b4f6dc4690cf2c194311bb498abf0cf4f7485"
+                "reference": "16ed5bdfd18e14fc7de347c8688e8ac479284222"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/d49b4f6dc4690cf2c194311bb498abf0cf4f7485",
-                "reference": "d49b4f6dc4690cf2c194311bb498abf0cf4f7485",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/16ed5bdfd18e14fc7de347c8688e8ac479284222",
+                "reference": "16ed5bdfd18e14fc7de347c8688e8ac479284222",
                 "shasum": ""
             },
             "require": {
@@ -15545,7 +16192,7 @@
             "description": "Provides utilities for PHPUnit, especially user deprecation notices management",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/phpunit-bridge/tree/v6.4.3"
+                "source": "https://github.com/symfony/phpunit-bridge/tree/v6.4.4"
             },
             "funding": [
                 {
@@ -15561,7 +16208,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T14:51:35+00:00"
+            "time": "2024-02-08T14:08:19+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
@@ -15640,17 +16287,93 @@
             "time": "2024-01-29T20:11:03+00:00"
         },
         {
-            "name": "theseer/tokenizer",
-            "version": "1.2.2",
+            "name": "symfony/polyfill-php82",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96"
+                "url": "https://github.com/symfony/polyfill-php82.git",
+                "reference": "559d488c38784112c78b9bf17c5ce8366a265643"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
-                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+                "url": "https://api.github.com/repos/symfony/polyfill-php82/zipball/559d488c38784112c78b9bf17c5ce8366a265643",
+                "reference": "559d488c38784112c78b9bf17c5ce8366a265643",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php82\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php82/tree/v1.29.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-29T20:11:03+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
                 "shasum": ""
             },
             "require": {
@@ -15679,7 +16402,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.2"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
             },
             "funding": [
                 {
@@ -15687,7 +16410,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-11-20T00:12:19+00:00"
+            "time": "2024-03-03T12:36:25+00:00"
         },
         {
             "name": "vimeo/psalm",

--- a/drupal/composer.lock
+++ b/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1aaf84202389c4ef6a845b48f458d95a",
+    "content-hash": "9a08636624f67898a389b3c5de9d86e2",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2626,6 +2626,10 @@
                     "homepage": "https://shadcn.com"
                 },
                 {
+                    "name": "minnur",
+                    "homepage": "https://www.drupal.org/user/702026"
+                },
+                {
                     "name": "roaguicr",
                     "homepage": "https://www.drupal.org/user/2334450"
                 },
@@ -2681,7 +2685,7 @@
             "extra": {
                 "drupal": {
                     "version": "8.x-1.17",
-                    "datestamp": "1705234146",
+                    "datestamp": "1709804220",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -16734,5 +16738,5 @@
         "php": ">=8.2"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/drupal/patches/recipe-10.2.x.patch
+++ b/drupal/patches/recipe-10.2.x.patch
@@ -1,0 +1,6900 @@
+diff --git a/core/core.services.yml b/core/core.services.yml
+index 746bed441a..c707ba1ee0 100644
+--- a/core/core.services.yml
++++ b/core/core.services.yml
+@@ -65,6 +65,10 @@ parameters:
+ services:
+   _defaults:
+     autoconfigure: true
++  plugin.manager.config_action:
++    class: Drupal\Core\Config\Action\ConfigActionManager
++    parent: default_plugin_manager
++    arguments: ['@config.manager', '@config.storage']
+   # Simple cache contexts, directly derived from the request context.
+   cache_context.ip:
+     class: Drupal\Core\Cache\Context\IpCacheContext
+@@ -360,6 +364,14 @@ services:
+     public: false
+     tags:
+       - { name: backend_overridable }
++  config.storage.checkpoint:
++    class: Drupal\Core\Config\Checkpoint\CheckpointStorage
++    arguments: [ '@config.storage', '@config.checkpoints', '@keyvalue' ]
++    tags:
++      - { name: event_subscriber }
++  config.checkpoints:
++    class: Drupal\Core\Config\Checkpoint\LinearHistory
++    arguments: [ '@state', '@datetime.time' ]
+   config.import_transformer:
+     class: Drupal\Core\Config\ImportStorageTransformer
+     arguments: ['@event_dispatcher', '@database', '@lock', '@lock.persistent']
+diff --git a/core/lib/Drupal/Core/Config/Action/Annotation/ConfigAction.php b/core/lib/Drupal/Core/Config/Action/Annotation/ConfigAction.php
+new file mode 100644
+index 0000000000..810ac20564
+--- /dev/null
++++ b/core/lib/Drupal/Core/Config/Action/Annotation/ConfigAction.php
+@@ -0,0 +1,47 @@
++<?php
++
++namespace Drupal\Core\Config\Action\Annotation;
++
++use Drupal\Component\Annotation\Plugin;
++use Drupal\Core\Annotation\Translation;
++use Drupal\Core\StringTranslation\TranslatableMarkup;
++
++/**
++ * Defines a ConfigAction annotation object.
++ *
++ * @ingroup config_action_api
++ *
++ * @Annotation
++ */
++class ConfigAction extends Plugin {
++
++  /**
++   * The plugin ID.
++   *
++   * @var string
++   */
++  public string $id;
++
++  /**
++   * The administrative label of the config action.
++   *
++   * @var \Drupal\Core\Annotation\Translation|\Drupal\Core\StringTranslation\TranslatableMarkup|string
++   *
++   * @ingroup plugin_translatable
++   */
++  public Translation|TranslatableMarkup|string $admin_label = '';
++
++  /**
++   * Allows action shorthand IDs for the listed config entity types.
++   *
++   * If '*' is present in the array then it can apply to all entity types. An
++   * empty array means that shorthand action IDs are not available for this
++   * plugin.
++   *
++   * @see \Drupal\Core\Config\Action\ConfigActionManager::convertActionToPluginId()
++   *
++   * @var string[]
++   */
++  public array $entity_types = [];
++
++}
+diff --git a/core/lib/Drupal/Core/Config/Action/Attribute/ActionMethod.php b/core/lib/Drupal/Core/Config/Action/Attribute/ActionMethod.php
+new file mode 100644
+index 0000000000..0463871b17
+--- /dev/null
++++ b/core/lib/Drupal/Core/Config/Action/Attribute/ActionMethod.php
+@@ -0,0 +1,39 @@
++<?php
++
++namespace Drupal\Core\Config\Action\Attribute;
++
++// cspell:ignore inflector
++use Drupal\Core\Config\Action\Exists;
++use Drupal\Core\StringTranslation\TranslatableMarkup;
++
++/**
++ * @internal
++ *   This API is experimental.
++ */
++#[\Attribute(\Attribute::TARGET_METHOD)]
++final class ActionMethod {
++
++  /**
++   * @param \Drupal\Core\Config\Action\Exists $exists
++   *   Determines behavior of action depending on entity existence.
++   * @param \Drupal\Core\StringTranslation\TranslatableMarkup|string $adminLabel
++   *   The admin label for the user interface.
++   * @param bool|string $pluralize
++   *   Determines whether to create a pluralized version of the method to enable
++   *   the action to be called multiple times before saving the entity. The
++   *   default behavior is to create an action with a plural form as determined
++   *   by \Symfony\Component\String\Inflector\EnglishInflector::pluralize().
++   *   For example, 'grantPermission' has a pluralized version of
++   *   'grantPermissions'. If a string is provided this will be the full action
++   *   ID. For example, if the method is called 'addArray' this can be set to
++   *   'addMultipleArrays'. Set to FALSE if a pluralized version does not make
++   *   logical sense.
++   */
++  public function __construct(
++    public readonly Exists $exists = Exists::ERROR_IF_NOT_EXISTS,
++    public readonly TranslatableMarkup|string $adminLabel = '',
++    public readonly bool|string $pluralize = TRUE
++  ) {
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Config/Action/ConfigActionException.php b/core/lib/Drupal/Core/Config/Action/ConfigActionException.php
+new file mode 100644
+index 0000000000..02e5220e34
+--- /dev/null
++++ b/core/lib/Drupal/Core/Config/Action/ConfigActionException.php
+@@ -0,0 +1,10 @@
++<?php
++
++namespace Drupal\Core\Config\Action;
++
++/**
++ * @internal
++ *   This API is experimental.
++ */
++final class ConfigActionException extends \RuntimeException {
++}
+diff --git a/core/lib/Drupal/Core/Config/Action/ConfigActionManager.php b/core/lib/Drupal/Core/Config/Action/ConfigActionManager.php
+new file mode 100644
+index 0000000000..539d472631
+--- /dev/null
++++ b/core/lib/Drupal/Core/Config/Action/ConfigActionManager.php
+@@ -0,0 +1,184 @@
++<?php
++
++namespace Drupal\Core\Config\Action;
++
++use Drupal\Component\Plugin\PluginBase;
++use Drupal\Core\Cache\CacheBackendInterface;
++use Drupal\Core\Config\ConfigManagerInterface;
++use Drupal\Core\Config\StorageInterface;
++use Drupal\Core\Extension\ModuleHandlerInterface;
++use Drupal\Core\Plugin\DefaultPluginManager;
++
++/**
++ * @defgroup config_action_api Config Action API
++ * @{
++ * Information about the classes and interfaces that make up the Config Action
++ * API.
++ *
++ * Configuration actions are plugins that manipulate simple configuration or
++ * configuration entities. The configuration action plugin manager can apply
++ * configuration actions. For example, the API is leveraged by recipes to create
++ * roles if they do not exist already and grant permissions to those roles.
++ *
++ * To define a configuration action in a module you need to:
++ * - Define a Config Action plugin by creating a new class that implements the
++ *   \Drupal\Core\Config\Action\ConfigActionPluginInterface, in namespace
++ *   Plugin\ConfigAction under your module namespace. For more information about
++ *   creating plugins, see the @link plugin_api Plugin API topic. @endlink
++ * - Config action plugins use the annotations defined by
++ *  \Drupal\Core\Config\Action\Annotation\ConfigAction. See the
++ *   @link annotation Annotations topic @endlink for more information about
++ *   annotations.
++ *
++ * Further information and examples:
++ * - \Drupal\Core\Config\Action\Plugin\ConfigAction\EntityMethod derives
++ *   configuration actions from config entity methods which have the
++ *   \Drupal\Core\Config\Action\Attribute\ActionMethod attribute.
++ * - \Drupal\Core\Config\Action\Plugin\ConfigAction\EntityCreate allows you to
++ *   create configuration entities if they do not exist.
++ * - \Drupal\Core\Config\Action\Plugin\ConfigAction\SimpleConfigUpdate allows
++ *   you to update simple configuration using a config action.
++ * @}
++ */
++class ConfigActionManager extends DefaultPluginManager {
++
++  /**
++   * Constructs a new \Drupal\Core\Config\Action\ConfigActionManager object.
++   *
++   * @param \Traversable $namespaces
++   *   An object that implements \Traversable which contains the root paths
++   *   keyed by the corresponding namespace to look for plugin implementations.
++   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
++   *   Cache backend instance to use.
++   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
++   *   The module handler to invoke the alter hook with.
++   * @param \Drupal\Core\Config\ConfigManagerInterface $configManager
++   *   The config manager.
++   * @param \Drupal\Core\Config\StorageInterface $configStorage
++   *   The active config storage.
++   */
++  public function __construct(
++    \Traversable $namespaces,
++    CacheBackendInterface $cache_backend,
++    ModuleHandlerInterface $module_handler,
++    protected readonly ConfigManagerInterface $configManager,
++    protected readonly StorageInterface $configStorage,
++  ) {
++    assert($namespaces instanceof \ArrayAccess, '$namespaces can be accessed like an array');
++    // Enable this namespace to be searched for plugins.
++    $namespaces[__NAMESPACE__] = 'core/lib/Drupal/Core/Config/Action';
++
++    parent::__construct('Plugin/ConfigAction', $namespaces, $module_handler, 'Drupal\Core\Config\Action\ConfigActionPluginInterface', 'Drupal\Core\Config\Action\Annotation\ConfigAction');
++
++    $this->alterInfo('config_action');
++    $this->setCacheBackend($cache_backend, 'config_action');
++  }
++
++  /**
++   * Applies a config action.
++   *
++   * @param string $action_id
++   *   The ID of the action to apply. This can be a complete configuration
++   *   action plugin ID or a shorthand action ID that is available for the
++   *   entity type of the provided configuration name.
++   * @param string $configName
++   *   The configuration name.
++   * @param mixed $data
++   *   The data for the action.
++   *
++   * @throws \Drupal\Component\Plugin\Exception\PluginException
++   *   Thrown when the config action cannot be found.
++   * @throws \Drupal\Core\Config\Action\ConfigActionException
++   *   Thrown when the config action fails to apply.
++   */
++  public function applyAction(string $action_id, string $configName, mixed $data): void {
++    if (!$this->hasDefinition($action_id)) {
++      // Get the full plugin ID from the shorthand map, if it is available.
++      $entity_type = $this->configManager->getEntityTypeIdByName($configName);
++      if ($entity_type) {
++        $action_id = $this->getShorthandActionIdsForEntityType($entity_type)[$action_id] ?? $action_id;
++      }
++    }
++    /** @var \Drupal\Core\Config\Action\ConfigActionPluginInterface $action */
++    $action = $this->createInstance($action_id);
++    foreach ($this->getConfigNamesMatchingExpression($configName) as $name) {
++      $action->apply($name, $data);
++    }
++  }
++
++  /**
++   * Gets the names of all active config objects that match an expression.
++   *
++   * @param string $expression
++   *   The expression to match. This may be the full name of a config object,
++   *   or it may contain wildcards (to target all config entities of a specific
++   *   type, or a subset thereof). For example:
++   *   - `user.role.*` would target all user roles.
++   *   - `user.role.anonymous` would target only the anonymous user role.
++   *   - `core.entity_view_display.node.*.default` would target the default
++   *     view display of every content type.
++   *   - `core.entity_form_display.*.*.default` would target the default form
++   *     display of every bundle of every entity type.
++   *   The expression MUST begin with the prefix of a config entity type --
++   *   for example, `field.field.` in the case of fields, or `user.role.` for
++   *   user roles. The prefix cannot contain wildcards.
++   *
++   * @return string[]
++   *   The names of all active config objects that match the expression.
++   *
++   * @throws \Drupal\Core\Config\Action\ConfigActionException
++   *   Thrown if the expression does not match any known config entity type's
++   *   prefix, or if the expression cannot be parsed.
++   */
++  private function getConfigNamesMatchingExpression(string $expression): array {
++    // If there are no wildcards, we can return the config name as-is.
++    if (!str_contains($expression, '.*')) {
++      return [$expression];
++    }
++
++    $entity_type = $this->configManager->getEntityTypeIdByName($expression);
++    if (empty($entity_type)) {
++      throw new ConfigActionException("No installed config entity type uses the prefix in the expression '$expression'. Either there is a typo in the expression or this recipe should install an additional module or depend on another recipe.");
++    }
++    /** @var \Drupal\Core\Config\Entity\ConfigEntityTypeInterface $entity_type */
++    $entity_type = $this->configManager->getEntityTypeManager()
++      ->getDefinition($entity_type);
++    $prefix = $entity_type->getConfigPrefix();
++
++    // Convert the expression to a regular expression. We assume that * should
++    // match the characters allowed by
++    // \Drupal\Core\Config\ConfigBase::validateName(), which is permissive.
++    $expression = str_replace('\\*', '[^.:?*<>"\'\/\\\\]+', preg_quote($expression));
++    $matches = @preg_grep("/^$expression$/", $this->configStorage->listAll("$prefix."));
++    if ($matches === FALSE) {
++      throw new ConfigActionException("The expression '$expression' could not be parsed.");
++    }
++    return $matches;
++  }
++
++  /**
++   * Gets a map of shorthand action IDs to plugin IDs for an entity type.
++   *
++   * @param string $entityType
++   *   The entity type ID to get the map for.
++   *
++   * @return string[]
++   *   An array of plugin IDs keyed by shorthand action ID for the provided
++   *   entity type.
++   */
++  protected function getShorthandActionIdsForEntityType(string $entityType): array {
++    $map = [];
++    foreach ($this->getDefinitions() as $plugin_id => $definition) {
++      if (in_array($entityType, $definition['entity_types'], TRUE) || in_array('*', $definition['entity_types'], TRUE)) {
++        $regex = '/' . PluginBase::DERIVATIVE_SEPARATOR . '([^' . PluginBase::DERIVATIVE_SEPARATOR . ']*)$/';
++        $action_id = preg_match($regex, $plugin_id, $matches) ? $matches[1] : $plugin_id;
++        if (isset($map[$action_id])) {
++          throw new DuplicateConfigActionIdException(sprintf('The plugins \'%s\' and \'%s\' both resolve to the same shorthand action ID for the \'%s\' entity type', $plugin_id, $map[$action_id], $entityType));
++        }
++        $map[$action_id] = $plugin_id;
++      }
++    }
++    return $map;
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Config/Action/ConfigActionPluginInterface.php b/core/lib/Drupal/Core/Config/Action/ConfigActionPluginInterface.php
+new file mode 100644
+index 0000000000..143ce3a3d2
+--- /dev/null
++++ b/core/lib/Drupal/Core/Config/Action/ConfigActionPluginInterface.php
+@@ -0,0 +1,19 @@
++<?php
++
++namespace Drupal\Core\Config\Action;
++
++interface ConfigActionPluginInterface {
++
++  /**
++   * Applies the config action.
++   *
++   * @param string $configName
++   *   The name of the config to apply the action to.
++   * @param mixed $value
++   *   The value for the action to use.
++   *
++   * @throws ConfigActionException
++   */
++  public function apply(string $configName, mixed $value): void;
++
++}
+diff --git a/core/lib/Drupal/Core/Config/Action/DuplicateConfigActionIdException.php b/core/lib/Drupal/Core/Config/Action/DuplicateConfigActionIdException.php
+new file mode 100644
+index 0000000000..7f6bdd3f0e
+--- /dev/null
++++ b/core/lib/Drupal/Core/Config/Action/DuplicateConfigActionIdException.php
+@@ -0,0 +1,9 @@
++<?php
++
++namespace Drupal\Core\Config\Action;
++
++/**
++ * Exception thrown if there are conflicting shorthand action IDs.
++ */
++class DuplicateConfigActionIdException extends \RuntimeException {
++}
+diff --git a/core/lib/Drupal/Core/Config/Action/EntityMethodException.php b/core/lib/Drupal/Core/Config/Action/EntityMethodException.php
+new file mode 100644
+index 0000000000..3a7b564421
+--- /dev/null
++++ b/core/lib/Drupal/Core/Config/Action/EntityMethodException.php
+@@ -0,0 +1,10 @@
++<?php
++
++namespace Drupal\Core\Config\Action;
++
++/**
++ * @internal
++ *   This API is experimental.
++ */
++final class EntityMethodException extends \RuntimeException {
++}
+diff --git a/core/lib/Drupal/Core/Config/Action/Exists.php b/core/lib/Drupal/Core/Config/Action/Exists.php
+new file mode 100644
+index 0000000000..ec34b5740d
+--- /dev/null
++++ b/core/lib/Drupal/Core/Config/Action/Exists.php
+@@ -0,0 +1,42 @@
++<?php
++// phpcs:ignoreFile
++
++namespace Drupal\Core\Config\Action;
++
++use Drupal\Core\Config\Entity\ConfigEntityInterface;
++
++/**
++ * @internal
++ *   This API is experimental.
++ */
++enum Exists {
++  case ERROR_IF_EXISTS;
++  case ERROR_IF_NOT_EXISTS;
++  case RETURN_EARLY_IF_EXISTS;
++  case RETURN_EARLY_IF_NOT_EXISTS;
++
++  /**
++   * Determines if an action should return early depending on $entity.
++   *
++   * @param string $configName
++   *   The config name supplied to the action.
++   * @param \Drupal\Core\Config\Entity\ConfigEntityInterface|null $entity
++   *   The entity, if it exists.
++   *
++   * @return bool
++   *   TRUE if the action should return early, FALSE if not.
++   *
++   * @throws \Drupal\Core\Config\Action\ConfigActionException
++   *   Thrown depending on $entity and the value of $this.
++   */
++  public function returnEarly(string $configName, ?ConfigEntityInterface $entity): bool {
++    return match (TRUE) {
++      $this === self::RETURN_EARLY_IF_EXISTS && $entity !== NULL,
++      $this === self::RETURN_EARLY_IF_NOT_EXISTS && $entity === NULL => TRUE,
++      $this === self::ERROR_IF_EXISTS && $entity !== NULL => throw new ConfigActionException(sprintf('Entity %s exists', $configName)),
++      $this === self::ERROR_IF_NOT_EXISTS && $entity === NULL => throw new ConfigActionException(sprintf('Entity %s does not exist', $configName)),
++      default => FALSE
++    };
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Config/Action/Plugin/ConfigAction/Deriver/EntityCreateDeriver.php b/core/lib/Drupal/Core/Config/Action/Plugin/ConfigAction/Deriver/EntityCreateDeriver.php
+new file mode 100644
+index 0000000000..8f42f7ad9a
+--- /dev/null
++++ b/core/lib/Drupal/Core/Config/Action/Plugin/ConfigAction/Deriver/EntityCreateDeriver.php
+@@ -0,0 +1,32 @@
++<?php
++
++namespace Drupal\Core\Config\Action\Plugin\ConfigAction\Deriver;
++
++use Drupal\Component\Plugin\Derivative\DeriverBase;
++use Drupal\Core\Config\Action\Exists;
++use Drupal\Core\StringTranslation\StringTranslationTrait;
++
++/**
++ * @internal
++ *   This API is experimental.
++ */
++class EntityCreateDeriver extends DeriverBase {
++  use StringTranslationTrait;
++
++  /**
++   * {@inheritdoc}
++   */
++  public function getDerivativeDefinitions($base_plugin_definition) {
++    // These derivatives apply to all entity types.
++    $base_plugin_definition['entity_types'] = ['*'];
++
++    $this->derivatives['ensure_exists'] = $base_plugin_definition + ['constructor_args' => ['exists' => Exists::RETURN_EARLY_IF_EXISTS]];
++    $this->derivatives['ensure_exists']['admin_label'] = $this->t('Ensure entity exists');
++
++    $this->derivatives['create'] = $base_plugin_definition + ['constructor_args' => ['exists' => Exists::ERROR_IF_EXISTS]];
++    $this->derivatives['create']['admin_label'] = $this->t('Entity create');
++
++    return $this->derivatives;
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Config/Action/Plugin/ConfigAction/Deriver/EntityMethodDeriver.php b/core/lib/Drupal/Core/Config/Action/Plugin/ConfigAction/Deriver/EntityMethodDeriver.php
+new file mode 100644
+index 0000000000..fe99550c6c
+--- /dev/null
++++ b/core/lib/Drupal/Core/Config/Action/Plugin/ConfigAction/Deriver/EntityMethodDeriver.php
+@@ -0,0 +1,141 @@
++<?php
++
++namespace Drupal\Core\Config\Action\Plugin\ConfigAction\Deriver;
++
++// cspell:ignore inflector
++use Drupal\Component\Plugin\Derivative\DeriverBase;
++use Drupal\Component\Plugin\PluginBase;
++use Drupal\Core\Config\Action\Attribute\ActionMethod;
++use Drupal\Core\Config\Action\EntityMethodException;
++use Drupal\Core\Config\Entity\ConfigEntityTypeInterface;
++use Drupal\Core\Entity\EntityTypeManagerInterface;
++use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
++use Drupal\Core\StringTranslation\StringTranslationTrait;
++use Symfony\Component\DependencyInjection\ContainerInterface;
++use Symfony\Component\String\Inflector\EnglishInflector;
++use Symfony\Component\String\Inflector\InflectorInterface;
++
++/**
++ * Derives config action methods from attributed config entity methods.
++ *
++ * @internal
++ *   This API is experimental.
++ */
++final class EntityMethodDeriver extends DeriverBase implements ContainerDeriverInterface {
++
++  use StringTranslationTrait;
++
++  /**
++   * Inflector to pluralize words.
++   */
++  protected readonly InflectorInterface $inflector;
++
++  /**
++   * Constructs new EntityMethodDeriver.
++   *
++   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
++   *   The entity type manager.
++   */
++  public function __construct(protected readonly EntityTypeManagerInterface $entityTypeManager) {
++    $this->inflector = new EnglishInflector();
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public static function create(ContainerInterface $container, $base_plugin_id) {
++    return new static(
++      $container->get('entity_type.manager')
++    );
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function getDerivativeDefinitions($base_plugin_definition) {
++    // Scan all the config entity classes for attributes.
++    foreach ($this->entityTypeManager->getDefinitions() as $entity_type) {
++      if ($entity_type instanceof ConfigEntityTypeInterface) {
++        $reflectionClass = new \ReflectionClass($entity_type->getClass());
++        while ($reflectionClass) {
++          foreach ($reflectionClass->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
++            // Only process a method if it is declared on the current class.
++            // Methods on the parent class will be processed later. This allows
++            // for a parent to have an attribute and an overriding class does
++            // not need one. For example,
++            // \Drupal\layout_builder\Entity\LayoutBuilderEntityViewDisplay::setComponent()
++            // and \Drupal\Core\Entity\EntityDisplayBase::setComponent().
++            if ($method->getDeclaringClass()->getName() === $reflectionClass->getName()) {
++              foreach ($method->getAttributes(ActionMethod::class) as $attribute) {
++                $this->processMethod($method, $attribute->newInstance(), $entity_type, $base_plugin_definition);
++              }
++            }
++          }
++          $reflectionClass = $reflectionClass->getParentClass();
++        }
++      }
++    }
++    return $this->derivatives;
++  }
++
++  /**
++   * Processes a method to create derivatives.
++   *
++   * @param \ReflectionMethod $method
++   *   The entity method.
++   * @param \Drupal\Core\Config\Action\Attribute\ActionMethod $action_attribute
++   *   The entity method attribute.
++   * @param \Drupal\Core\Config\Entity\ConfigEntityTypeInterface $entity_type
++   *   The entity type.
++   * @param array $derivative
++   *   The base plugin definition that will used to create the derivative.
++   */
++  private function processMethod(\ReflectionMethod $method, ActionMethod $action_attribute, ConfigEntityTypeInterface $entity_type, array $derivative): void {
++    $derivative['admin_label'] = $action_attribute->adminLabel ?: $this->t('@entity_type @method', ['@entity_type' => $entity_type->getLabel(), '@method' => $method->name]);
++    $derivative['constructor_args'] = [
++      'method' => $method->name,
++      'exists' => $action_attribute->exists,
++      'numberOfParams' => $method->getNumberOfParameters(),
++      'numberOfRequiredParams' => $method->getNumberOfRequiredParameters(),
++      'pluralized' => FALSE,
++    ];
++    $derivative['entity_types'] = [$entity_type->id()];
++    // Build a config action identifier from the entity type's config
++    // prefix  and the method name. For example, the Role entity adds a
++    // 'user.role:grantPermission' action.
++    $this->addDerivative($method->name, $entity_type, $derivative, $method->name);
++
++    $pluralized_name = match(TRUE) {
++      is_string($action_attribute->pluralize) => $action_attribute->pluralize,
++      $action_attribute->pluralize === FALSE => '',
++      default => $this->inflector->pluralize($method->name)[0]
++    };
++    // Add a pluralized version of the plugin.
++    if (strlen($pluralized_name) > 0) {
++      $derivative['constructor_args']['pluralized'] = TRUE;
++      $derivative['admin_label'] = $this->t('@admin_label (multiple calls)', ['@admin_label' => $derivative['admin_label']]);
++      $this->addDerivative($pluralized_name, $entity_type, $derivative, $method->name);
++    }
++  }
++
++  /**
++   * Adds a derivative.
++   *
++   * @param string $action_id
++   *   The action ID.
++   * @param \Drupal\Core\Config\Entity\ConfigEntityTypeInterface $entity_type
++   *   The entity type.
++   * @param array $derivative
++   *   The derivative definition.
++   * @param string $methodName
++   *   The method name.
++   */
++  private function addDerivative(string $action_id, ConfigEntityTypeInterface $entity_type, array $derivative, string $methodName): void {
++    $id = $entity_type->getConfigPrefix() . PluginBase::DERIVATIVE_SEPARATOR . $action_id;
++    if (isset($this->derivatives[$id])) {
++      throw new EntityMethodException(sprintf('Duplicate action can not be created for ID \'%s\' for %s::%s(). The existing action is for the ::%s() method', $id, $entity_type->getClass(), $methodName, $this->derivatives[$id]['constructor_args']['method']));
++    }
++    $this->derivatives[$id] = $derivative;
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Config/Action/Plugin/ConfigAction/EntityCreate.php b/core/lib/Drupal/Core/Config/Action/Plugin/ConfigAction/EntityCreate.php
+new file mode 100644
+index 0000000000..f86f64fb3a
+--- /dev/null
++++ b/core/lib/Drupal/Core/Config/Action/Plugin/ConfigAction/EntityCreate.php
+@@ -0,0 +1,74 @@
++<?php
++
++namespace Drupal\Core\Config\Action\Plugin\ConfigAction;
++
++use Drupal\Core\Config\Action\ConfigActionException;
++use Drupal\Core\Config\Action\ConfigActionPluginInterface;
++use Drupal\Core\Config\Action\Exists;
++use Drupal\Core\Config\ConfigManagerInterface;
++use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
++use Symfony\Component\DependencyInjection\ContainerInterface;
++
++/**
++ * @ConfigAction(
++ *   id = "entity_create",
++ *   deriver = "\Drupal\Core\Config\Action\Plugin\ConfigAction\Deriver\EntityCreateDeriver",
++ * )
++ *
++ * @internal
++ *   This API is experimental.
++ */
++final class EntityCreate implements ConfigActionPluginInterface, ContainerFactoryPluginInterface {
++
++  /**
++   * Constructs a EntityCreate object.
++   *
++   * @param \Drupal\Core\Config\ConfigManagerInterface $configManager
++   *   The config manager.
++   * @param \Drupal\Core\Config\Action\Exists $exists
++   *   Determines behavior of action depending on entity existence.
++   */
++  public function __construct(
++    protected readonly ConfigManagerInterface $configManager,
++    protected readonly Exists $exists
++  ) {
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
++    assert(is_array($plugin_definition) && is_array($plugin_definition['constructor_args']), '$plugin_definition contains the expected settings');
++    return new static($container->get('config.manager'), ...$plugin_definition['constructor_args']);
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function apply(string $configName, mixed $value): void {
++    if (!is_array($value)) {
++      throw new ConfigActionException(sprintf("The value provided to create %s must be an array", $configName));
++    }
++
++    /** @var \Drupal\Core\Config\Entity\ConfigEntityInterface|null $entity */
++    $entity = $this->configManager->loadConfigEntityByName($configName);
++    if ($this->exists->returnEarly($configName, $entity)) {
++      return;
++    }
++
++    $entity_type_manager = $this->configManager->getEntityTypeManager();
++    $entity_type_id = $this->configManager->getEntityTypeIdByName($configName);
++    if ($entity_type_id === NULL) {
++      throw new ConfigActionException(sprintf("Cannot determine a config entity type from %s", $configName));
++    }
++    /** @var \Drupal\Core\Config\Entity\ConfigEntityTypeInterface $entity_type */
++    $entity_type = $entity_type_manager->getDefinition($entity_type_id);
++
++    $id = substr($configName, strlen($entity_type->getConfigPrefix()) + 1);
++    $entity_type_manager
++      ->getStorage($entity_type->id())
++      ->create($value + ['id' => $id])
++      ->save();
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Config/Action/Plugin/ConfigAction/EntityMethod.php b/core/lib/Drupal/Core/Config/Action/Plugin/ConfigAction/EntityMethod.php
+new file mode 100644
+index 0000000000..a04bd63732
+--- /dev/null
++++ b/core/lib/Drupal/Core/Config/Action/Plugin/ConfigAction/EntityMethod.php
+@@ -0,0 +1,146 @@
++<?php
++
++namespace Drupal\Core\Config\Action\Plugin\ConfigAction;
++
++use Drupal\Core\Config\Action\ConfigActionPluginInterface;
++use Drupal\Core\Config\Action\EntityMethodException;
++use Drupal\Core\Config\Action\Exists;
++use Drupal\Core\Config\ConfigManagerInterface;
++use Drupal\Core\Config\Entity\ConfigEntityInterface;
++use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
++use Symfony\Component\DependencyInjection\ContainerInterface;
++
++/**
++ * Makes config entity methods with the ActionMethod attribute into actions.
++ *
++ * For example, adding the ActionMethod attribute to
++ * \Drupal\user\Entity\Role::grantPermission() allows permissions to be added to
++ * roles via config actions.
++ *
++ * When calling \Drupal\Core\Config\Action\ConfigActionManager::applyAction()
++ * the $data parameter is mapped to the method's arguments using the following
++ * rules:
++ * - If $data is not an array, the method must only have one argument or one
++ *   required argument.
++ * - If $data is an array and the method only accepts a single argument, the
++ *   array will be passed to the first argument.
++ * - If $data is an array and the method accepts more than one argument, $data
++ *   will be unpacked into the method arguments.
++ *
++ * @ConfigAction(
++ *   id = "entity_method",
++ *   deriver = "\Drupal\Core\Config\Action\Plugin\ConfigAction\Deriver\EntityMethodDeriver",
++ * )
++ *
++ * @internal
++ *   This API is experimental.
++ *
++ * @see \Drupal\Core\Config\Action\Attribute\ActionMethod
++ */
++final class EntityMethod implements ConfigActionPluginInterface, ContainerFactoryPluginInterface {
++
++  /**
++   * Constructs a EntityMethod object.
++   *
++   * @param string $pluginId
++   *   The config action plugin ID.
++   * @param \Drupal\Core\Config\ConfigManagerInterface $configManager
++   *   The config manager.
++   * @param string $method
++   *   The method to call on the config entity.
++   * @param \Drupal\Core\Config\Action\Exists $exists
++   *   Determines behavior of action depending on entity existence.
++   * @param int $numberOfParams
++   *   The number of parameters the method has.
++   * @param int $numberOfRequiredParams
++   *   The number of required parameters the method has.
++   * @param bool $pluralized
++   *   Determines whether an array maps to multiple calls.
++   */
++  public function __construct(
++    protected readonly string $pluginId,
++    protected readonly ConfigManagerInterface $configManager,
++    protected readonly string $method,
++    protected readonly Exists $exists,
++    protected readonly int $numberOfParams,
++    protected readonly int $numberOfRequiredParams,
++    protected readonly bool $pluralized
++  ) {
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
++    assert(is_array($plugin_definition) && is_array($plugin_definition['constructor_args']), '$plugin_definition contains the expected settings');
++    return new static(
++      $plugin_id,
++      $container->get('config.manager'),
++      ...$plugin_definition['constructor_args']
++    );
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function apply(string $configName, mixed $value): void {
++    /** @var \Drupal\Core\Config\Entity\ConfigEntityInterface|null $entity */
++    $entity = $this->configManager->loadConfigEntityByName($configName);
++    if ($this->exists->returnEarly($configName, $entity)) {
++      return;
++    }
++
++    $entity = $this->pluralized ? $this->applyPluralized($entity, $value) : $this->applySingle($entity, $value);
++    $entity->save();
++  }
++
++  /**
++   * Apply the action to entity treating the $values array as multiple calls.
++   *
++   * @param \Drupal\Core\Config\Entity\ConfigEntityInterface $entity
++   *   The entity to apply the action to.
++   * @param mixed $values
++   *   The values for the action to use.
++   *
++   * @return \Drupal\Core\Config\Entity\ConfigEntityInterface
++   *   The unsaved entity with the action applied.
++   */
++  private function applyPluralized(ConfigEntityInterface $entity, mixed $values): ConfigEntityInterface {
++    if (!is_array($values)) {
++      throw new EntityMethodException(sprintf('The pluralized entity method config action \'%s\' requires an array value in order to call %s::%s() multiple times', $this->pluginId, $entity->getEntityType()->getClass(), $this->method));
++    }
++    foreach ($values as $value) {
++      $entity = $this->applySingle($entity, $value);
++    }
++    return $entity;
++  }
++
++  /**
++   * Apply the action to entity treating the $values array a single call.
++   *
++   * @param \Drupal\Core\Config\Entity\ConfigEntityInterface $entity
++   *   The entity to apply the action to.
++   * @param mixed $value
++   *   The value for the action to use.
++   *
++   * @return \Drupal\Core\Config\Entity\ConfigEntityInterface
++   *   The unsaved entity with the action applied.
++   */
++  private function applySingle(ConfigEntityInterface $entity, mixed $value): ConfigEntityInterface {
++    // If $value is not an array then we only support calling the method if the
++    // number of parameters or required parameters is 1. If there is only 1
++    // parameter and $value is an array then assume that the parameter expects
++    // an array.
++    if (!is_array($value) || $this->numberOfParams === 1) {
++      if ($this->numberOfRequiredParams !== 1 && $this->numberOfParams !== 1) {
++        throw new EntityMethodException(sprintf('Entity method config action \'%s\' requires an array value. The number of parameters or required parameters for %s::%s() is not 1', $this->pluginId, $entity->getEntityType()->getClass(), $this->method));
++      }
++      $entity->{$this->method}($value);
++    }
++    else {
++      $entity->{$this->method}(...$value);
++    }
++    return $entity;
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Config/Action/Plugin/ConfigAction/SimpleConfigUpdate.php b/core/lib/Drupal/Core/Config/Action/Plugin/ConfigAction/SimpleConfigUpdate.php
+new file mode 100644
+index 0000000000..5f46c65a9c
+--- /dev/null
++++ b/core/lib/Drupal/Core/Config/Action/Plugin/ConfigAction/SimpleConfigUpdate.php
+@@ -0,0 +1,60 @@
++<?php
++
++namespace Drupal\Core\Config\Action\Plugin\ConfigAction;
++
++use Drupal\Core\Config\Action\ConfigActionException;
++use Drupal\Core\Config\Action\ConfigActionPluginInterface;
++use Drupal\Core\Config\ConfigFactoryInterface;
++use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
++use Symfony\Component\DependencyInjection\ContainerInterface;
++
++/**
++ * @ConfigAction(
++ *   id = "simple_config_update",
++ *   admin_label = @Translation("Simple configuration update")
++ * )
++ *
++ * @internal
++ *   This API is experimental.
++ */
++final class SimpleConfigUpdate implements ConfigActionPluginInterface, ContainerFactoryPluginInterface {
++
++  /**
++   * Constructs a SimpleConfigUpdate object.
++   *
++   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
++   *   The config factory.
++   */
++  public function __construct(
++    protected readonly ConfigFactoryInterface $configFactory,
++  ) {
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
++    return new static($container->get('config.factory'));
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function apply(string $configName, mixed $value): void {
++    $config = $this->configFactory->getEditable($configName);
++    // @todo Should we error if this is a config entity?
++    if ($config->isNew()) {
++      throw new ConfigActionException(sprintf('Config %s does not exist so can not be updated', $configName));
++    }
++
++    // Expect $value to be an array whose keys are the config keys to update.
++    if (!is_array($value)) {
++      throw new ConfigActionException(sprintf('Config %s can not be updated because $value is not an array', $configName));
++    }
++    foreach ($value as $key => $value) {
++      $config->set($key, $value);
++    }
++    $config->save();
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Config/Checkpoint/Checkpoint.php b/core/lib/Drupal/Core/Config/Checkpoint/Checkpoint.php
+new file mode 100644
+index 0000000000..96fa498317
+--- /dev/null
++++ b/core/lib/Drupal/Core/Config/Checkpoint/Checkpoint.php
+@@ -0,0 +1,32 @@
++<?php
++
++declare(strict_types=1);
++
++namespace Drupal\Core\Config\Checkpoint;
++
++/**
++ * A value object to store information about a checkpoint.
++ */
++final class Checkpoint {
++
++  /**
++   * Constructs a checkpoint object.
++   *
++   * @param string $id
++   *   The checkpoint's ID.
++   * @param \Stringable|string $label
++   *   The human-readable label.
++   * @param int $timestamp
++   *   The timestamp when the checkpoint was created.
++   * @param string|null $parent
++   *   The ID of the checkpoint's parent.
++   */
++  public function __construct(
++    public readonly string $id,
++    public readonly \Stringable|string $label,
++    public readonly int $timestamp,
++    public readonly ?string $parent,
++  ) {
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Config/Checkpoint/CheckpointExistsException.php b/core/lib/Drupal/Core/Config/Checkpoint/CheckpointExistsException.php
+new file mode 100644
+index 0000000000..320022f29f
+--- /dev/null
++++ b/core/lib/Drupal/Core/Config/Checkpoint/CheckpointExistsException.php
+@@ -0,0 +1,9 @@
++<?php
++
++namespace Drupal\Core\Config\Checkpoint;
++
++/**
++ * Thrown when trying to add a checkpoint with an ID that already exists.
++ */
++final class CheckpointExistsException extends \RuntimeException {
++}
+diff --git a/core/lib/Drupal/Core/Config/Checkpoint/CheckpointListInterface.php b/core/lib/Drupal/Core/Config/Checkpoint/CheckpointListInterface.php
+new file mode 100644
+index 0000000000..ef60e217c4
+--- /dev/null
++++ b/core/lib/Drupal/Core/Config/Checkpoint/CheckpointListInterface.php
+@@ -0,0 +1,83 @@
++<?php
++
++namespace Drupal\Core\Config\Checkpoint;
++
++/**
++ * Maintains a list of checkpoints.
++ *
++ * @see \Drupal\Core\Config\Checkpoint\Checkpoint
++ *
++ * @phpstan-extends \IteratorAggregate<string, \Drupal\Core\Config\Checkpoint\Checkpoint>
++ */
++interface CheckpointListInterface extends \IteratorAggregate, \Countable {
++
++  /**
++   * Gets the active checkpoint.
++   *
++   * @return \Drupal\Core\Config\Checkpoint\Checkpoint|null
++   *   The active checkpoint or NULL if there are no checkpoints.
++   */
++  public function getActiveCheckpoint(): ?Checkpoint;
++
++  /**
++   * Gets a checkpoint.
++   *
++   * @param string $id
++   *   The checkpoint ID.
++   *
++   * @return \Drupal\Core\Config\Checkpoint\Checkpoint
++   *   The checkpoint.
++   *
++   * @throws \Drupal\Core\Config\Checkpoint\UnknownCheckpointException
++   *   Thrown when the provided checkpoint does not exist.
++   */
++  public function get(string $id): Checkpoint;
++
++  /**
++   * Gets a checkpoint's parents.
++   *
++   * @param string $id
++   *   The checkpoint ID.
++   *
++   * @return iterable<string, \Drupal\Core\Config\Checkpoint\Checkpoint>
++   */
++  public function getParents(string $id): iterable;
++
++  /**
++   * Adds a new checkpoint.
++   *
++   * @param string $id
++   *   The ID of the checkpoint add.
++   * @param string|\Stringable $label
++   *   The checkpoint label.
++   *
++   * @return \Drupal\Core\Config\Checkpoint\Checkpoint
++   *   The new checkpoint, which is now at the end of the checkpoint sequence.
++   *
++   * @throws \Drupal\Core\Config\Checkpoint\CheckpointExistsException
++   *   Thrown when the ID already exists.
++   */
++  public function add(string $id, string|\Stringable $label): Checkpoint;
++
++  /**
++   * Deletes a checkpoint.
++   *
++   * @param string $id
++   *   The ID of the checkpoint to delete up to: only checkpoints after this one
++   *   will remain.
++   *
++   * @return $this
++   *
++   * @throws \Drupal\Core\Config\Checkpoint\UnknownCheckpointException
++   *   Thrown when provided checkpoint ID does not exist.
++   */
++  public function delete(string $id): static;
++
++  /**
++   * Deletes all checkpoints.
++   *
++   * @return $this
++   */
++  public function deleteAll(): static;
++
++}
+diff --git a/core/lib/Drupal/Core/Config/Checkpoint/CheckpointStorage.php b/core/lib/Drupal/Core/Config/Checkpoint/CheckpointStorage.php
+new file mode 100644
+index 0000000000..5ec4a5bd5c
+--- /dev/null
++++ b/core/lib/Drupal/Core/Config/Checkpoint/CheckpointStorage.php
+@@ -0,0 +1,487 @@
++<?php
++
++declare(strict_types=1);
++
++namespace Drupal\Core\Config\Checkpoint;
++
++use Drupal\Core\Config\Config;
++use Drupal\Core\Config\ConfigCollectionEvents;
++use Drupal\Core\Config\ConfigCrudEvent;
++use Drupal\Core\Config\ConfigEvents;
++use Drupal\Core\Config\ConfigRenameEvent;
++use Drupal\Core\Config\StorableConfigBase;
++use Drupal\Core\Config\StorageInterface;
++use Drupal\Core\KeyValueStore\KeyValueFactoryInterface;
++use Drupal\Core\KeyValueStore\KeyValueStoreInterface;
++use Symfony\Component\EventDispatcher\EventSubscriberInterface;
++
++/**
++ * Provides a config storage that can make checkpoints.
++ *
++ * This storage wraps the active storage, and provides the ability to take
++ * checkpoints. Once a checkpoint has been created all configuration operations
++ * made after the checkpoint will be recorded, so it is possible to revert to
++ * original state when the checkpoint was taken.
++ *
++ * This class cannot be used to checkpoint another storage since it relies on
++ * events triggered by the configuration system in order to work. It is the
++ * responsibility of the caller to construct this class with the active storage.
++ */
++final class CheckpointStorage implements CheckpointStorageInterface, EventSubscriberInterface {
++
++  /**
++   * Used as prefix to a config checkpoint collection.
++   *
++   * If this code is copied in order to checkpoint a different storage then
++   * this value must be changed.
++   */
++  private const KEY_VALUE_COLLECTION_PREFIX = 'config.checkpoint.';
++
++  /**
++   * Used to store the list of collections in each checkpoint.
++   *
++   * Note this cannot be a valid configuration name.
++   *
++   * @see \Drupal\Core\Config\ConfigBase::validateName()
++   */
++  private const CONFIG_COLLECTION_KEY = 'collections';
++
++  /**
++   * The key value stores that store configuration changed for each checkpoint.
++   *
++   * @var \Drupal\Core\KeyValueStore\KeyValueStoreInterface[]
++   */
++  private array $keyValueStores;
++
++  /**
++   * The checkpoint to read from.
++   *
++   * @var \Drupal\Core\Config\Checkpoint\Checkpoint|null
++   */
++  private ?Checkpoint $readFromCheckpoint = NULL;
++
++  /**
++   * Constructs a CheckpointStorage object.
++   *
++   * @param \Drupal\Core\Config\StorageInterface $activeStorage
++   *   The active configuration storage.
++   * @param \Drupal\Core\Config\Checkpoint\CheckpointListInterface $checkpoints
++   *   The list of checkpoints.
++   * @param \Drupal\Core\KeyValueStore\KeyValueFactoryInterface $keyValueFactory
++   *   The key value factory.
++   * @param string $collection
++   *   (optional) The configuration collection.
++   */
++  public function __construct(
++    private readonly StorageInterface $activeStorage,
++    private readonly CheckpointListInterface $checkpoints,
++    private readonly KeyValueFactoryInterface $keyValueFactory,
++    private readonly string $collection = StorageInterface::DEFAULT_COLLECTION,
++  ) {
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function exists($name) {
++    if (count($this->checkpoints) === 0) {
++      throw new NoCheckpointsException();
++    }
++
++    foreach ($this->getCheckpointsToReadFrom() as $checkpoint) {
++      $in_checkpoint = $this->getKeyValue($checkpoint->id, $this->collection)->get($name);
++      if ($in_checkpoint !== NULL) {
++        // If $in_checkpoint is FALSE then the configuration has been deleted.
++        return $in_checkpoint !== FALSE;
++      }
++    }
++    return $this->activeStorage->exists($name);
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function read($name) {
++    $return = $this->readMultiple([$name]);
++    return $return[$name] ?? FALSE;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function readMultiple(array $names) {
++    if (count($this->checkpoints) === 0) {
++      throw new NoCheckpointsException();
++    }
++    $return = [];
++
++    foreach ($this->getCheckpointsToReadFrom() as $checkpoint) {
++      $return = array_merge(
++        $return,
++        $this->getKeyValue($checkpoint->id, $this->collection)->getMultiple($names)
++      );
++      // Remove the read names from the list to fetch.
++      $names = array_diff($names, array_keys($return));
++      if (empty($names)) {
++        // All the configuration has been read. Nothing more to do.
++        break;
++      }
++    }
++
++    // Names not found in the checkpoints have not been modified: read from
++    // active storage.
++    if (!empty($names)) {
++      $return = array_merge(
++        $return,
++        $this->activeStorage->readMultiple($names)
++      );
++    }
++
++    // Remove any renamed or new configuration (FALSE has been recorded for
++    // these operations in the checkpoint).
++    // @see ::onConfigRename()
++    // @see ::onConfigSaveAndDelete()
++    return array_filter($return);
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function encode($data) {
++    return $this->activeStorage->encode($data);
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function decode($raw) {
++    return $this->activeStorage->decode($raw);
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function listAll($prefix = '') {
++    if (count($this->checkpoints) === 0) {
++      throw new NoCheckpointsException();
++    }
++
++    $names = $new_configuration = [];
++
++    foreach ($this->getCheckpointsToReadFrom() as $checkpoint) {
++      $checkpoint_names = array_keys(array_filter($this->getKeyValue($checkpoint->id, $this->collection)->getAll(), function (mixed $value, string $name) use (&$new_configuration, $prefix) {
++        if ($name === static::CONFIG_COLLECTION_KEY) {
++          return FALSE;
++        }
++        // Remove any that don't start with the prefix.
++        if ($prefix !== '' && !str_starts_with($name, $prefix)) {
++          return FALSE;
++        }
++        // We've determined in a previous checkpoint that the configuration did
++        // not exist.
++        if (in_array($name, $new_configuration, TRUE)) {
++          return FALSE;
++        }
++        // If the value is FALSE then the configuration was created after the
++        // checkpoint.
++        if ($value === FALSE) {
++          $new_configuration[] = $name;
++          return FALSE;
++        }
++        return TRUE;
++      }, ARRAY_FILTER_USE_BOTH));
++      $names = array_merge($names, $checkpoint_names);
++    }
++
++    // Remove any names that did not exist prior to the checkpoint.
++    $active_names = array_diff($this->activeStorage->listAll($prefix), $new_configuration);
++
++    $names = array_unique(array_merge($names, $active_names));
++    sort($names);
++    return $names;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function createCollection($collection) {
++    $collection = new self(
++      $this->activeStorage->createCollection($collection),
++      $this->checkpoints,
++      $this->keyValueFactory,
++      $collection
++    );
++    // \Drupal\Core\Config\Checkpoint\CheckpointStorage::$readFromCheckpoint is
++    // assigned by reference so that it is  consistent across all collection
++    // objects created from the same initial object.
++    $collection->readFromCheckpoint = &$this->readFromCheckpoint;
++    return $collection;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function getAllCollectionNames() {
++    $names = [];
++    foreach ($this->getCheckpointsToReadFrom() as $checkpoint) {
++      $names = array_merge(
++        $names,
++        $this->getKeyValue($checkpoint->id, StorageInterface::DEFAULT_COLLECTION)->get(static::CONFIG_COLLECTION_KEY, [])
++      );
++    }
++    return array_unique(array_merge($this->activeStorage->getAllCollectionNames(), $names));
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function getCollectionName() {
++    return $this->collection;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function checkpoint(string|\Stringable $label): Checkpoint {
++    // Generate a new ID based on the state of the current active checkpoint.
++    $active_checkpoint = $this->checkpoints->getActiveCheckpoint();
++    if ($active_checkpoint instanceof Checkpoint) {
++      $collections = $this->getAllCollectionNames();
++      $collections[] = StorageInterface::DEFAULT_COLLECTION;
++      foreach ($collections as $collection) {
++        $current_checkpoint_data[$collection] = $this->getKeyValue($active_checkpoint->id, $collection)->getAll();
++        // Remove the collections key because it is irrelevant.
++        unset($current_checkpoint_data[$collection][static::CONFIG_COLLECTION_KEY]);
++        // If there is no data in the collection then there is no need to hash
++        // the empty array.
++        if (empty($current_checkpoint_data[$collection])) {
++          unset($current_checkpoint_data[$collection]);
++        }
++      }
++
++      if (!empty($current_checkpoint_data)) {
++        // Use json_encode() here because it is both quicker and results in
++        // smaller output than serialize().
++        $id = hash('sha1', ($active_checkpoint->parent ?? '') . json_encode($current_checkpoint_data));
++        $active_checkpoint = $this->checkpoints->add($id, $label);
++      }
++      else {
++        // @todo https://www.drupal.org/project/distributions_recipes/issues/3408523
++        //   Decide on the correct behavior here.
++      }
++    }
++    else {
++      // @todo https://www.drupal.org/project/distributions_recipes/issues/3408525
++      //   Consider options for generating a real fingerprint.
++      $id = hash('sha1', random_bytes(32));
++      $active_checkpoint = $this->checkpoints->add($id, $label);
++    }
++
++    return $active_checkpoint;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function setCheckpointToReadFrom(string|Checkpoint $checkpoint_id): static {
++    if ($checkpoint_id instanceof Checkpoint) {
++      $checkpoint_id = $checkpoint_id->id;
++    }
++    $this->readFromCheckpoint = $this->checkpoints->get($checkpoint_id);
++    return $this;
++  }
++
++  /**
++   * Gets the key value storage for the provided checkpoint.
++   *
++   * @param string $checkpoint
++   *   The checkpoint to get the key value storage for.
++   * @param string $collection
++   *   The config collection to get the key value storage for.
++   *
++   * @return \Drupal\Core\KeyValueStore\KeyValueStoreInterface
++   *   The key value storage for the provided checkpoint.
++   */
++  private function getKeyValue(string $checkpoint, string $collection): KeyValueStoreInterface {
++    $checkpoint_key = $checkpoint;
++    if ($collection !== StorageInterface::DEFAULT_COLLECTION) {
++      $checkpoint_key = $collection . '.' . $checkpoint_key;
++    }
++    return $this->keyValueStores[$checkpoint_key] ??= $this->keyValueFactory->get(self::KEY_VALUE_COLLECTION_PREFIX . $checkpoint_key);
++  }
++
++  /**
++   * Gets the checkpoints to read from.
++   *
++   * @return \Traversable<string, \Drupal\Core\Config\Checkpoint\Checkpoint>
++   *   The checkpoints, keyed by ID.
++   */
++  private function getCheckpointsToReadFrom(): \Traversable {
++    $checkpoint = $this->checkpoints->getActiveCheckpoint();
++
++    /** @var \Drupal\Core\Config\Checkpoint\Checkpoint[] $checkpoints_to_read_from */
++    $checkpoints_to_read_from = [$checkpoint];
++    if ($checkpoint->id !== $this->readFromCheckpoint?->id) {
++      // Follow ancestors to find the checkpoint to start reading from.
++      foreach ($this->checkpoints->getParents($checkpoint->id) as $checkpoint) {
++        array_unshift($checkpoints_to_read_from, $checkpoint);
++        if ($checkpoint->id === $this->readFromCheckpoint?->id) {
++          break;
++        }
++      }
++    }
++
++    // Replay in parent to child order.
++    foreach ($checkpoints_to_read_from as $checkpoint) {
++      yield $checkpoint->id => $checkpoint;
++    }
++  }
++
++  /**
++   * Updates checkpoint when configuration is saved.
++   *
++   * @param \Drupal\Core\Config\ConfigCrudEvent $event
++   *   The configuration event.
++   */
++  public function onConfigSaveAndDelete(ConfigCrudEvent $event): void {
++    $active_checkpoint = $this->checkpoints->getActiveCheckpoint();
++    if ($active_checkpoint === NULL) {
++      return;
++    }
++
++    $saved_config = $event->getConfig();
++    $collection = $saved_config->getStorage()->getCollectionName();
++    $this->storeCollectionName($collection);
++
++    $key_value = $this->getKeyValue($active_checkpoint->id, $collection);
++
++    // If we have not yet stored a checkpoint for this configuration we should.
++    if ($key_value->get($saved_config->getName()) === NULL) {
++      $original_data = $this->getOriginalConfig($saved_config);
++      // An empty array indicates that the config has to be new as a sequence
++      // cannot be the root of a config object. We need to make this assumption
++      // because $saved_config->isNew() will always return FALSE here.
++      if (empty($original_data)) {
++        $original_data = FALSE;
++      }
++      // Only save change to state if there is a change, even if it's just keys
++      // being re-ordered.
++      if ($original_data !== $saved_config->getRawData()) {
++        $key_value->set($saved_config->getName(), $original_data);
++      }
++    }
++  }
++
++  /**
++   * Updates checkpoint when configuration is saved.
++   *
++   * @param \Drupal\Core\Config\ConfigRenameEvent $event
++   *   The configuration event.
++   */
++  public function onConfigRename(ConfigRenameEvent $event): void {
++    $active_checkpoint = $this->checkpoints->getActiveCheckpoint();
++    if ($active_checkpoint === NULL) {
++      return;
++    }
++    $collection = $event->getConfig()->getStorage()->getCollectionName();
++    $this->storeCollectionName($collection);
++
++    $key_value = $this->getKeyValue($active_checkpoint->id, $collection);
++
++    $old_name = $event->getOldName();
++
++    // If we have not yet stored a checkpoint for this configuration, store a
++    // complete copy of the original configuration. Note that renames do not
++    // change data but storing the complete data allows
++    // \Drupal\Core\Config\ConfigImporter to track renames using UUIDs.
++    if ($key_value->get($old_name) === NULL) {
++      $key_value->set($old_name, $this->getOriginalConfig($event->getConfig()));
++    }
++
++    // Record that the new name did not exist prior to the checkpoint.
++    $new_name = $event->getConfig()->getName();
++    if ($key_value->get($new_name) === NULL) {
++      $key_value->set($new_name, FALSE);
++    }
++  }
++
++  /**
++   * Gets the original data from the configuration.
++   *
++   * @param \Drupal\Core\Config\StorableConfigBase $config
++   *   The config to get the original data from.
++   *
++   * @return mixed
++   *   The original data.
++   */
++  private function getOriginalConfig(StorableConfigBase $config): mixed {
++    if ($config instanceof Config) {
++      return $config->getOriginal(apply_overrides: FALSE);
++    }
++    return $config->getOriginal();
++  }
++
++  /**
++   * Stores the collection name so the storage knows its own collections.
++   *
++   * @param string $collection
++   *   The name of the collection.
++   */
++  private function storeCollectionName(string $collection): void {
++    // We do not need to store the default collection.
++    if ($collection === StorageInterface::DEFAULT_COLLECTION) {
++      return;
++    }
++
++    $key_value = $this->getKeyValue($this->checkpoints->getActiveCheckpoint()->id, StorageInterface::DEFAULT_COLLECTION);
++    $collections = $key_value->get(static::CONFIG_COLLECTION_KEY, []);
++    assert(is_array($collections));
++    if (in_array($collection, $collections, TRUE)) {
++      return;
++    }
++    $collections[] = $collection;
++    $key_value->set(static::CONFIG_COLLECTION_KEY, $collections);
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public static function getSubscribedEvents(): array {
++    $events[ConfigEvents::SAVE][] = 'onConfigSaveAndDelete';
++    $events[ConfigEvents::DELETE][] = 'onConfigSaveAndDelete';
++    $events[ConfigEvents::RENAME][] = 'onConfigRename';
++    $events[ConfigCollectionEvents::SAVE_IN_COLLECTION][] = 'onConfigSaveAndDelete';
++    $events[ConfigCollectionEvents::DELETE_IN_COLLECTION][] = 'onConfigSaveAndDelete';
++    $events[ConfigCollectionEvents::RENAME_IN_COLLECTION][] = 'onConfigRename';
++    return $events;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function write($name, array $data): never {
++    throw new \BadMethodCallException(__METHOD__ . ' is not allowed on a CheckpointStorage');
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function delete($name): never {
++    throw new \BadMethodCallException(__METHOD__ . ' is not allowed on a CheckpointStorage');
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function rename($name, $new_name): never {
++    throw new \BadMethodCallException(__METHOD__ . ' is not allowed on a CheckpointStorage');
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function deleteAll($prefix = ''): never {
++    throw new \BadMethodCallException(__METHOD__ . ' is not allowed on a CheckpointStorage');
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Config/Checkpoint/CheckpointStorageInterface.php b/core/lib/Drupal/Core/Config/Checkpoint/CheckpointStorageInterface.php
+new file mode 100644
+index 0000000000..1539cd18d5
+--- /dev/null
++++ b/core/lib/Drupal/Core/Config/Checkpoint/CheckpointStorageInterface.php
+@@ -0,0 +1,43 @@
++<?php
++
++namespace Drupal\Core\Config\Checkpoint;
++
++use Drupal\Core\Config\StorageInterface;
++
++/**
++ * Provides an interface for checkpoint storages.
++ */
++interface CheckpointStorageInterface extends StorageInterface {
++
++  /**
++   * Creates a checkpoint, if required, and returns the active checkpoint.
++   *
++   * If the storage determines that the current active checkpoint would contain
++   * the same information, it does not have to create a new checkpoint.
++   *
++   * @param string|\Stringable $label
++   *   The checkpoint label to use if a new checkpoint is created.
++   *
++   * @return \Drupal\Core\Config\Checkpoint\Checkpoint
++   *   The currently active checkpoint.
++   */
++  public function checkpoint(string|\Stringable $label): Checkpoint;
++
++  /**
++   * Sets the checkpoint to read from.
++   *
++   * Calling read() or readMultiple() will return the configuration data at the
++   * time of the checkpoint that was set here. If none is set, then the
++   * configuration from the initial checkpoint will be returned.
++   *
++   * @param string|\Drupal\Core\Config\Checkpoint\Checkpoint $checkpoint_id
++   *   The checkpoint ID to read from.
++   *
++   * @return $this
++   *
++   * @throws \Drupal\Core\Config\Checkpoint\UnknownCheckpointException
++   *   Thrown when the provided checkpoint does not exist.
++   */
++  public function setCheckpointToReadFrom(string|Checkpoint $checkpoint_id): static;
++
++}
+diff --git a/core/lib/Drupal/Core/Config/Checkpoint/LinearHistory.php b/core/lib/Drupal/Core/Config/Checkpoint/LinearHistory.php
+new file mode 100644
+index 0000000000..65bd02501a
+--- /dev/null
++++ b/core/lib/Drupal/Core/Config/Checkpoint/LinearHistory.php
+@@ -0,0 +1,141 @@
++<?php
++
++declare(strict_types=1);
++
++namespace Drupal\Core\Config\Checkpoint;
++
++use Drupal\Component\Datetime\TimeInterface;
++use Drupal\Core\State\StateInterface;
++
++/**
++ * A chronological list of Checkpoint objects.
++ */
++final class LinearHistory implements CheckpointListInterface {
++
++  /**
++   * The store of all the checkpoint names in state.
++   */
++  private const CHECKPOINT_KEY = 'config.checkpoints';
++
++  /**
++   * The active checkpoint.
++   *
++   * In our implementation this is always the last in the list.
++   *
++   * @var \Drupal\Core\Config\Checkpoint\Checkpoint|null
++   */
++  private ?Checkpoint $activeCheckpoint;
++
++  /**
++   * The list of checkpoints, keyed by ID.
++   *
++   * @var \Drupal\Core\Config\Checkpoint\Checkpoint[]
++   */
++  private array $checkpoints;
++
++  /**
++   * Constructs a checkpoints object.
++   *
++   * @param \Drupal\Core\State\StateInterface $state
++   *   The state service.
++   * @param \Drupal\Component\Datetime\TimeInterface $time
++   *   The time service.
++   */
++  public function __construct(
++    private readonly StateInterface $state,
++    private readonly TimeInterface $time,
++  ) {
++    $this->checkpoints = $this->state->get(self::CHECKPOINT_KEY, []);
++    $this->activeCheckpoint = end($this->checkpoints) ?: NULL;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function getActiveCheckpoint(): ?Checkpoint {
++    return $this->activeCheckpoint;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function get(string $id): Checkpoint {
++    if (!isset($this->checkpoints[$id])) {
++      throw new UnknownCheckpointException(sprintf('The checkpoint "%s" does not exist', $id));
++    }
++    return $this->checkpoints[$id];
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function getParents(string $id): \Traversable {
++    if (!isset($this->checkpoints[$id])) {
++      throw new UnknownCheckpointException(sprintf('The checkpoint "%s" does not exist', $id));
++    }
++    $checkpoint = $this->checkpoints[$id];
++    while ($checkpoint->parent !== NULL) {
++      $checkpoint = $this->get($checkpoint->parent);
++      yield $checkpoint->id => $checkpoint;
++    }
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function getIterator(): \Traversable {
++    return new \ArrayIterator($this->checkpoints);
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function count(): int {
++    return count($this->checkpoints);
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function add(string $id, string|\Stringable $label): Checkpoint {
++    if (isset($this->checkpoints[$id])) {
++      throw new CheckpointExistsException(sprintf('Cannot create a checkpoint with the ID "%s" as it already exists', $id));
++    }
++    $checkpoint = new Checkpoint($id, $label, $this->time->getCurrentTime(), $this->activeCheckpoint?->id);
++    $this->checkpoints[$checkpoint->id] = $checkpoint;
++    $this->activeCheckpoint = $checkpoint;
++    $this->state->set(self::CHECKPOINT_KEY, $this->checkpoints);
++
++    return $checkpoint;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function delete(string $id): static {
++    if (!isset($this->checkpoints[$id])) {
++      throw new UnknownCheckpointException(sprintf('Cannot delete a checkpoint with the ID "%s" as it does not exist', $id));
++    }
++
++    foreach ($this->checkpoints as $key => $checkpoint) {
++      unset($this->checkpoints[$key]);
++      if ($checkpoint->id === $id) {
++        break;
++      }
++    }
++    $this->state->set(self::CHECKPOINT_KEY, $this->checkpoints);
++
++    return $this;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function deleteAll(): static {
++    $this->checkpoints = [];
++    $this->activeCheckpoint = NULL;
++    $this->state->delete(self::CHECKPOINT_KEY);
++    return $this;
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Config/Checkpoint/NoCheckpointsException.php b/core/lib/Drupal/Core/Config/Checkpoint/NoCheckpointsException.php
+new file mode 100644
+index 0000000000..9a26a2c6ed
+--- /dev/null
++++ b/core/lib/Drupal/Core/Config/Checkpoint/NoCheckpointsException.php
+@@ -0,0 +1,15 @@
++<?php
++
++namespace Drupal\Core\Config\Checkpoint;
++
++/**
++ * Thrown when using the checkpoint storage with no checkpoints.
++ */
++final class NoCheckpointsException extends \RuntimeException {
++
++  /**
++   * {@inheritdoc}
++   */
++  protected $message = 'This storage cannot be read because there are no checkpoints';
++
++}
+diff --git a/core/lib/Drupal/Core/Config/Checkpoint/UnknownCheckpointException.php b/core/lib/Drupal/Core/Config/Checkpoint/UnknownCheckpointException.php
+new file mode 100644
+index 0000000000..1d6dd928f2
+--- /dev/null
++++ b/core/lib/Drupal/Core/Config/Checkpoint/UnknownCheckpointException.php
+@@ -0,0 +1,9 @@
++<?php
++
++namespace Drupal\Core\Config\Checkpoint;
++
++/**
++ * Thrown when trying to access a checkpoint that does not exist.
++ */
++final class UnknownCheckpointException extends \RuntimeException {
++}
+diff --git a/core/lib/Drupal/Core/Config/Config.php b/core/lib/Drupal/Core/Config/Config.php
+index abcb41fe7e..9048403a2f 100644
+--- a/core/lib/Drupal/Core/Config/Config.php
++++ b/core/lib/Drupal/Core/Config/Config.php
+@@ -226,7 +226,8 @@ public function save($has_trusted_data = FALSE) {
+       Cache::invalidateTags($this->getCacheTags());
+     }
+     $this->isNew = FALSE;
+-    $this->eventDispatcher->dispatch(new ConfigCrudEvent($this), ConfigEvents::SAVE);
++    $event_name = $this->getStorage()->getCollectionName() === StorageInterface::DEFAULT_COLLECTION ? ConfigEvents::SAVE : ConfigCollectionEvents::SAVE_IN_COLLECTION;
++    $this->eventDispatcher->dispatch(new ConfigCrudEvent($this), $event_name);
+     $this->originalData = $this->data;
+     return $this;
+   }
+@@ -243,21 +244,12 @@ public function delete() {
+     Cache::invalidateTags($this->getCacheTags());
+     $this->isNew = TRUE;
+     $this->resetOverriddenData();
+-    $this->eventDispatcher->dispatch(new ConfigCrudEvent($this), ConfigEvents::DELETE);
++    $event_name = $this->getStorage()->getCollectionName() === StorageInterface::DEFAULT_COLLECTION ? ConfigEvents::DELETE : ConfigCollectionEvents::DELETE_IN_COLLECTION;
++    $this->eventDispatcher->dispatch(new ConfigCrudEvent($this), $event_name);
+     $this->originalData = $this->data;
+     return $this;
+   }
+ 
+-  /**
+-   * Gets the raw data without overrides.
+-   *
+-   * @return array
+-   *   The raw data.
+-   */
+-  public function getRawData() {
+-    return $this->data;
+-  }
+-
+   /**
+    * Gets original data from this configuration object.
+    *
+diff --git a/core/lib/Drupal/Core/Config/ConfigCollectionEvents.php b/core/lib/Drupal/Core/Config/ConfigCollectionEvents.php
+new file mode 100644
+index 0000000000..e965953986
+--- /dev/null
++++ b/core/lib/Drupal/Core/Config/ConfigCollectionEvents.php
+@@ -0,0 +1,105 @@
++<?php
++
++namespace Drupal\Core\Config;
++
++/**
++ * Defines events for working with configuration collections.
++ *
++ * Configuration collections are often used to store configuration-related
++ * data, like overrides. The use case is determined by the module that provides
++ * the collection. A classic example is to store the translated parts of
++ * various configuration objects. Using a collection allows this data to be
++ * imported and exported alongside regular configuration. It also allows the
++ * data to be created when installing an extension. In both the import/export
++ * and extension installation situations, collection data is stored in
++ * subdirectories.
++ *
++ * @see \Drupal\Core\Config\ConfigCrudEvent
++ */
++final class ConfigCollectionEvents {
++
++  /**
++   * Event dispatched when saving configuration not in the default collection.
++   *
++   * This event allows modules to react whenever an object that extends
++   * \Drupal\Core\Config\StorableConfigBase is saved in a non-default
++   * collection. The event listener method receives a
++   * \Drupal\Core\Config\ConfigCrudEvent instance.
++   *
++   * Note: this event is not used for configuration in the default collection.
++   * See \Drupal\Core\Config\ConfigEvents::SAVE instead.
++   *
++   * @Event
++   *
++   * @var string
++   *
++   * @see \Drupal\Core\Config\ConfigCrudEvent
++   * @see \Drupal\Core\Config\ConfigFactoryOverrideInterface::createConfigObject()
++   * @see \Drupal\language\Config\LanguageConfigOverride::save()
++   *
++   * @see \Drupal\Core\Config\ConfigEvents::SAVE
++   */
++  const SAVE_IN_COLLECTION = 'config.save.collection';
++
++  /**
++   * Event dispatched when deleting configuration not in the default collection.
++   *
++   * This event allows modules to react whenever an object that extends
++   * \Drupal\Core\Config\StorableConfigBase is deleted in a non-default
++   * collection. The event listener method receives a
++   * \Drupal\Core\Config\ConfigCrudEvent instance.
++   *
++   * Note: this event is not used for configuration in the default collection.
++   * See \Drupal\Core\Config\ConfigEvents::DELETE instead.
++   *
++   * @Event
++   *
++   * @see \Drupal\Core\Config\ConfigEvents::DELETE
++   * @see \Drupal\Core\Config\ConfigCrudEvent
++   * @see \Drupal\Core\Config\ConfigFactoryOverrideInterface::createConfigObject()
++   * @see \Drupal\language\Config\LanguageConfigOverride::delete()
++   *
++   * @var string
++   */
++  const DELETE_IN_COLLECTION = 'config.delete.collection';
++
++  /**
++   * Event dispatched when renaming configuration not in the default collection.
++   *
++   * This event allows modules to react whenever an object that extends
++   * \Drupal\Core\Config\StorableConfigBase is renamed in a non-default
++   * collection. The event listener method receives a
++   * \Drupal\Core\Config\ConfigCrudEvent instance.
++   *
++   * Note: this event is not used for configuration in the default collection.
++   * See \Drupal\Core\Config\ConfigEvents::RENAME instead.
++   *
++   * @Event
++   *
++   * @see \Drupal\Core\Config\ConfigEvents::RENAME
++   * @see \Drupal\Core\Config\ConfigCrudEvent
++   * @see \Drupal\Core\Config\ConfigFactoryOverrideInterface::createConfigObject()
++   *
++   * @var string
++   */
++  const RENAME_IN_COLLECTION = 'config.rename.collection';
++
++  /**
++   * Event dispatched to collect information on all config collections.
++   *
++   * This event allows modules to add to the list of configuration collections
++   * retrieved by \Drupal\Core\Config\ConfigManager::getConfigCollectionInfo().
++   * The event listener method receives a
++   * \Drupal\Core\Config\ConfigCollectionInfo instance.
++   *
++   * @Event
++   *
++   * @see \Drupal\Core\Config\ConfigCollectionInfo
++   * @see \Drupal\Core\Config\ConfigManager::getConfigCollectionInfo()
++   * @see \Drupal\Core\Config\ConfigFactoryOverrideBase
++   *
++   * @var string
++   */
++  const COLLECTION_INFO = 'config.collection_info';
++
++}
+diff --git a/core/lib/Drupal/Core/Config/ConfigCrudEvent.php b/core/lib/Drupal/Core/Config/ConfigCrudEvent.php
+index 639e3031b4..63048bd753 100644
+--- a/core/lib/Drupal/Core/Config/ConfigCrudEvent.php
++++ b/core/lib/Drupal/Core/Config/ConfigCrudEvent.php
+@@ -19,17 +19,17 @@ class ConfigCrudEvent extends Event {
+   /**
+    * Constructs a configuration event object.
+    *
+-   * @param \Drupal\Core\Config\Config $config
++   * @param \Drupal\Core\Config\StorableConfigBase $config
+    *   Configuration object.
+    */
+-  public function __construct(Config $config) {
++  public function __construct(StorableConfigBase $config) {
+     $this->config = $config;
+   }
+ 
+   /**
+    * Gets configuration object.
+    *
+-   * @return \Drupal\Core\Config\Config
++   * @return \Drupal\Core\Config\StorableConfigBase
+    *   The configuration object that caused the event to fire.
+    */
+   public function getConfig() {
+diff --git a/core/lib/Drupal/Core/Config/ConfigEvents.php b/core/lib/Drupal/Core/Config/ConfigEvents.php
+index 8aa2d8d65f..ffb186c299 100644
+--- a/core/lib/Drupal/Core/Config/ConfigEvents.php
++++ b/core/lib/Drupal/Core/Config/ConfigEvents.php
+@@ -140,8 +140,13 @@ final class ConfigEvents {
+    * @see \Drupal\Core\Config\ConfigFactoryOverrideBase
+    *
+    * @var string
++   *
++   * @deprecated in drupal:10.3.0 and is removed from drupal:11.0.0. Use
++   *    \Drupal\Core\Config\ConfigCollectionEvents::COLLECTION_INFO instead.
++   *
++   * @see https://www.drupal.org/node/3406105
+    */
+-  const COLLECTION_INFO = 'config.collection_info';
++  const COLLECTION_INFO = ConfigCollectionEvents::COLLECTION_INFO;
+ 
+   /**
+    * Name of the event fired just before importing configuration.
+diff --git a/core/lib/Drupal/Core/Config/ConfigFactory.php b/core/lib/Drupal/Core/Config/ConfigFactory.php
+index ef0e22d482..e29c3710cc 100644
+--- a/core/lib/Drupal/Core/Config/ConfigFactory.php
++++ b/core/lib/Drupal/Core/Config/ConfigFactory.php
+@@ -260,7 +260,8 @@ public function rename($old_name, $new_name) {
+ 
+     // Prime the cache and load the configuration with the correct overrides.
+     $config = $this->get($new_name);
+-    $this->eventDispatcher->dispatch(new ConfigRenameEvent($config, $old_name), ConfigEvents::RENAME);
++    $event_name = $this->storage->getCollectionName() === StorageInterface::DEFAULT_COLLECTION ? ConfigEvents::RENAME : ConfigCollectionEvents::RENAME_IN_COLLECTION;
++    $this->eventDispatcher->dispatch(new ConfigRenameEvent($config, $old_name), $event_name);
+     return $this;
+   }
+ 
+diff --git a/core/lib/Drupal/Core/Config/ConfigFactoryOverrideBase.php b/core/lib/Drupal/Core/Config/ConfigFactoryOverrideBase.php
+index c859f7f9fc..ac27578a36 100644
+--- a/core/lib/Drupal/Core/Config/ConfigFactoryOverrideBase.php
++++ b/core/lib/Drupal/Core/Config/ConfigFactoryOverrideBase.php
+@@ -10,7 +10,7 @@
+ abstract class ConfigFactoryOverrideBase implements EventSubscriberInterface {
+ 
+   /**
+-   * Reacts to the ConfigEvents::COLLECTION_INFO event.
++   * Reacts to the ConfigCollectionEvents::COLLECTION_INFO event.
+    *
+    * @param \Drupal\Core\Config\ConfigCollectionInfo $collection_info
+    *   The configuration collection info event.
+@@ -45,7 +45,7 @@ abstract public function onConfigRename(ConfigRenameEvent $event);
+    * {@inheritdoc}
+    */
+   public static function getSubscribedEvents(): array {
+-    $events[ConfigEvents::COLLECTION_INFO][] = ['addCollections'];
++    $events[ConfigCollectionEvents::COLLECTION_INFO][] = ['addCollections'];
+     $events[ConfigEvents::SAVE][] = ['onConfigSave', 20];
+     $events[ConfigEvents::DELETE][] = ['onConfigDelete', 20];
+     $events[ConfigEvents::RENAME][] = ['onConfigRename', 20];
+diff --git a/core/lib/Drupal/Core/Config/ConfigFactoryOverrideInterface.php b/core/lib/Drupal/Core/Config/ConfigFactoryOverrideInterface.php
+index 13a78f8369..110b0c91b7 100644
+--- a/core/lib/Drupal/Core/Config/ConfigFactoryOverrideInterface.php
++++ b/core/lib/Drupal/Core/Config/ConfigFactoryOverrideInterface.php
+@@ -34,22 +34,32 @@ public function getCacheSuffix();
+    * it can have its own implementation of
+    * \Drupal\Core\Config\StorableConfigBase. Configuration overriders can link
+    * themselves to a configuration collection by listening to the
+-   * \Drupal\Core\Config\ConfigEvents::COLLECTION_INFO event and adding the
+-   * collections they are responsible for. Doing this will allow installation
+-   * and synchronization to use the overrider's implementation of
+-   * StorableConfigBase.
++   * \Drupal\Core\Config\ConfigCollectionEvents::COLLECTION_INFO event and
++   * adding the collections they are responsible for. Doing this will allow
++   * installation and synchronization to use the overrider's implementation of
++   * StorableConfigBase. Additionally, the overrider's implementation should
++   * trigger the appropriate event:
++   * - Saving and creating triggers ConfigCollectionEvents::SAVE_IN_COLLECTION.
++   * - Deleting triggers ConfigCollectionEvents::DELETE_IN_COLLECTION.
++   * - Renaming triggers ConfigCollectionEvents::RENAME_IN_COLLECTION.
+    *
+    * @see \Drupal\Core\Config\ConfigCollectionInfo
+    * @see \Drupal\Core\Config\ConfigImporter::importConfig()
+    * @see \Drupal\Core\Config\ConfigInstaller::createConfiguration()
++   * @see \Drupal\Core\Config\ConfigCollectionEvents::SAVE_IN_COLLECTION
++   * @see \Drupal\Core\Config\ConfigCollectionEvents::DELETE_IN_COLLECTION
++   * @see \Drupal\Core\Config\ConfigCollectionEvents::RENAME_IN_COLLECTION
+    *
+    * @param string $name
+    *   The configuration object name.
+    * @param string $collection
+    *   The configuration collection.
+    *
+-   * @return \Drupal\Core\Config\StorableConfigBase
+-   *   The configuration object for the provided name and collection.
++   * @return \Drupal\Core\Config\StorableConfigBase|null
++   *   The configuration object for the provided name and collection. NULL
++   *   should be returned when the overrider does not use configuration
++   *   collections. For example: a module that provides an overrider to avoid
++   *   storing API keys in config would not use collections.
+    */
+   public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION);
+ 
+diff --git a/core/lib/Drupal/Core/Config/ConfigManager.php b/core/lib/Drupal/Core/Config/ConfigManager.php
+index 5db500f2fe..fc49f26bc6 100644
+--- a/core/lib/Drupal/Core/Config/ConfigManager.php
++++ b/core/lib/Drupal/Core/Config/ConfigManager.php
+@@ -220,7 +220,17 @@ public function uninstall($type, $name) {
+     // Remove any matching configuration from collections.
+     foreach ($this->activeStorage->getAllCollectionNames() as $collection) {
+       $collection_storage = $this->activeStorage->createCollection($collection);
+-      $collection_storage->deleteAll($name . '.');
++      $overrider = $this->getConfigCollectionInfo()->getOverrideService($collection);
++      foreach ($collection_storage->listAll($name . '.') as $config_name) {
++        if ($overrider) {
++          $config = $overrider->createConfigObject($config_name, $collection);
++        }
++        else {
++          $config = new Config($config_name, $collection_storage, $this->eventDispatcher, $this->typedConfigManager);
++        }
++        $config->initWithData($collection_storage->read($config_name));
++        $config->delete();
++      }
+     }
+ 
+     $schema_dir = $this->extensionPathResolver->getPath($type, $name) . '/' . InstallStorage::CONFIG_SCHEMA_DIRECTORY;
+@@ -391,7 +401,7 @@ public function getConfigEntitiesToChangeOnDependencyRemoval($type, array $names
+   public function getConfigCollectionInfo() {
+     if (!isset($this->configCollectionInfo)) {
+       $this->configCollectionInfo = new ConfigCollectionInfo();
+-      $this->eventDispatcher->dispatch($this->configCollectionInfo, ConfigEvents::COLLECTION_INFO);
++      $this->eventDispatcher->dispatch($this->configCollectionInfo, ConfigCollectionEvents::COLLECTION_INFO);
+     }
+     return $this->configCollectionInfo;
+   }
+diff --git a/core/lib/Drupal/Core/Config/ConfigRenameEvent.php b/core/lib/Drupal/Core/Config/ConfigRenameEvent.php
+index 8f71559809..ba7441a0fa 100644
+--- a/core/lib/Drupal/Core/Config/ConfigRenameEvent.php
++++ b/core/lib/Drupal/Core/Config/ConfigRenameEvent.php
+@@ -17,12 +17,12 @@ class ConfigRenameEvent extends ConfigCrudEvent {
+   /**
+    * Constructs the config rename event.
+    *
+-   * @param \Drupal\Core\Config\Config $config
++   * @param \Drupal\Core\Config\StorableConfigBase $config
+    *   The configuration that has been renamed.
+    * @param string $old_name
+    *   The old configuration object name.
+    */
+-  public function __construct(Config $config, $old_name) {
++  public function __construct(StorableConfigBase $config, $old_name) {
+     $this->config = $config;
+     $this->oldName = $old_name;
+   }
+diff --git a/core/lib/Drupal/Core/Config/StorableConfigBase.php b/core/lib/Drupal/Core/Config/StorableConfigBase.php
+index ae521919d0..750f8f4f5e 100644
+--- a/core/lib/Drupal/Core/Config/StorableConfigBase.php
++++ b/core/lib/Drupal/Core/Config/StorableConfigBase.php
+@@ -2,6 +2,7 @@
+ 
+ namespace Drupal\Core\Config;
+ 
++use Drupal\Component\Utility\NestedArray;
+ use Drupal\Core\Config\Schema\Ignore;
+ use Drupal\Core\Config\Schema\Mapping;
+ use Drupal\Core\Config\Schema\Sequence;
+@@ -121,6 +122,47 @@ public function getStorage() {
+     return $this->storage;
+   }
+ 
++  /**
++   * Gets original data from this configuration object.
++   *
++   * Original data is the data as it is immediately after loading from
++   * configuration storage before any changes. If this is a new configuration
++   * object it will be an empty array.
++   *
++   * @see \Drupal\Core\Config\Config::get()
++   *
++   * @param string $key
++   *   A string that maps to a key within the configuration data.
++   *
++   * @return mixed
++   *   The data that was requested.
++   */
++  public function getOriginal($key = '') {
++    $original_data = $this->originalData;
++
++    if (empty($key)) {
++      return $original_data;
++    }
++
++    $parts = explode('.', $key);
++    if (count($parts) == 1) {
++      return $original_data[$key] ?? NULL;
++    }
++
++    $value = NestedArray::getValue($original_data, $parts, $key_exists);
++    return $key_exists ? $value : NULL;
++  }
++
++  /**
++   * Gets the raw data without any manipulations.
++   *
++   * @return array
++   *   The raw data.
++   */
++  public function getRawData() {
++    return $this->data;
++  }
++
+   /**
+    * Gets the schema wrapper for the whole configuration object.
+    *
+diff --git a/core/lib/Drupal/Core/Config/StorageInterface.php b/core/lib/Drupal/Core/Config/StorageInterface.php
+index b2e6d4abb0..9a2908cfc7 100644
+--- a/core/lib/Drupal/Core/Config/StorageInterface.php
++++ b/core/lib/Drupal/Core/Config/StorageInterface.php
+@@ -7,6 +7,11 @@
+  *
+  * Classes implementing this interface allow reading and writing configuration
+  * data from and to the storage.
++ *
++ * Note: this should never be used directly to work with active configuration.
++ * The values returned from it do not have the expected overrides and writing
++ * directly to the storage does not trigger configuration events. Use the
++ * 'config.factory' service and the configuration objects it provides.
+  */
+ interface StorageInterface {
+ 
+diff --git a/core/lib/Drupal/Core/Entity/EntityDisplayBase.php b/core/lib/Drupal/Core/Entity/EntityDisplayBase.php
+index 768835903f..4951ef32d7 100644
+--- a/core/lib/Drupal/Core/Entity/EntityDisplayBase.php
++++ b/core/lib/Drupal/Core/Entity/EntityDisplayBase.php
+@@ -2,10 +2,12 @@
+ 
+ namespace Drupal\Core\Entity;
+ 
++use Drupal\Core\Config\Action\Attribute\ActionMethod;
+ use Drupal\Core\Config\Entity\ConfigEntityBase;
+ use Drupal\Core\Config\Entity\ConfigEntityInterface;
+ use Drupal\Core\Field\FieldDefinitionInterface;
+ use Drupal\Core\Entity\Display\EntityDisplayInterface;
++use Drupal\Core\StringTranslation\TranslatableMarkup;
+ 
+ /**
+  * Provides a common base class for entity view and form displays.
+@@ -345,6 +347,7 @@ public function getComponent($name) {
+   /**
+    * {@inheritdoc}
+    */
++  #[ActionMethod(adminLabel: new TranslatableMarkup('Add component to display'))]
+   public function setComponent($name, array $options = []) {
+     // If no weight specified, make sure the field sinks at the bottom.
+     if (!isset($options['weight'])) {
+diff --git a/core/lib/Drupal/Core/Field/FieldConfigBase.php b/core/lib/Drupal/Core/Field/FieldConfigBase.php
+index ca9a5b5285..610977ec2d 100644
+--- a/core/lib/Drupal/Core/Field/FieldConfigBase.php
++++ b/core/lib/Drupal/Core/Field/FieldConfigBase.php
+@@ -2,10 +2,12 @@
+ 
+ namespace Drupal\Core\Field;
+ 
++use Drupal\Core\Config\Action\Attribute\ActionMethod;
+ use Drupal\Core\Config\Entity\ConfigEntityBase;
+ use Drupal\Core\Entity\EntityStorageInterface;
+ use Drupal\Core\Entity\FieldableEntityInterface;
+ use Drupal\Core\Field\TypedData\FieldItemDataDefinition;
++use Drupal\Core\StringTranslation\TranslatableMarkup;
+ 
+ /**
+  * Base class for configurable field definitions.
+@@ -327,6 +329,7 @@ public function getLabel() {
+   /**
+    * {@inheritdoc}
+    */
++  #[ActionMethod(adminLabel: new TranslatableMarkup('Change field label'))]
+   public function setLabel($label) {
+     $this->label = $label;
+     return $this;
+diff --git a/core/lib/Drupal/Core/Recipe/ConfigConfigurator.php b/core/lib/Drupal/Core/Recipe/ConfigConfigurator.php
+new file mode 100644
+index 0000000000..fc3db51ed5
+--- /dev/null
++++ b/core/lib/Drupal/Core/Recipe/ConfigConfigurator.php
+@@ -0,0 +1,103 @@
++<?php
++
++namespace Drupal\Core\Recipe;
++
++use Drupal\Core\Config\FileStorage;
++use Drupal\Core\Config\StorageInterface;
++
++/**
++ * @internal
++ *   This API is experimental.
++ */
++final class ConfigConfigurator {
++
++  public readonly ?string $recipeConfigDirectory;
++
++  /**
++   * @param array $config
++   *   Config options for a recipe.
++   * @param string $recipe_directory
++   *   The path to the recipe.
++   * @param \Drupal\Core\Config\StorageInterface $active_configuration
++   *   The active configuration storage.
++   */
++  public function __construct(public readonly array $config, string $recipe_directory, StorageInterface $active_configuration) {
++    // @todo validate structure of $config['import'] and $config['actions'].
++
++    $this->recipeConfigDirectory = is_dir($recipe_directory . '/config') ? $recipe_directory . '/config' : NULL;
++    $recipe_storage = $this->getConfigStorage();
++    foreach ($recipe_storage->listAll() as $config_name) {
++      if ($active_data = $active_configuration->read($config_name)) {
++        // @todo investigate if there is any generic code in core for this.
++        unset($active_data['uuid'], $active_data['_core']);
++        if (empty($active_data['dependencies'])) {
++          unset($active_data['dependencies']);
++        }
++        $recipe_data = $recipe_storage->read($config_name);
++        // Ensure we don't get a false mismatch due to differing key order.
++        // @todo When https://www.drupal.org/project/drupal/issues/3230826 is
++        //   fixed in core, use that API instead to sort the config data.
++        self::recursiveSortByKey($active_data);
++        self::recursiveSortByKey($recipe_data);
++        if ($active_data !== $recipe_data) {
++          throw new RecipePreExistingConfigException($config_name, sprintf("The configuration '%s' exists already and does not match the recipe's configuration", $config_name));
++        }
++      }
++    }
++  }
++
++  /**
++   * Sorts an array recursively, by key, alphabetically.
++   *
++   * @param mixed[] $data
++   *   The array to sort, passed by reference.
++   *
++   * @todo Remove when https://www.drupal.org/project/drupal/issues/3230826 is
++   *   fixed in core.
++   */
++  private static function recursiveSortByKey(array &$data): void {
++    // If the array is a list, it is by definition already sorted.
++    if (!array_is_list($data)) {
++      ksort($data);
++    }
++    foreach ($data as &$value) {
++      if (is_array($value)) {
++        self::recursiveSortByKey($value);
++      }
++    }
++  }
++
++  /**
++   * Gets a config storage object for reading config from the recipe.
++   *
++   * @return \Drupal\Core\Config\StorageInterface
++   *   The  config storage object for reading config from the recipe.
++   */
++  public function getConfigStorage(): StorageInterface {
++    $storages = [];
++
++    if ($this->recipeConfigDirectory) {
++      // Config provided by the recipe should take priority over config from
++      // extensions.
++      $storages[] = new FileStorage($this->recipeConfigDirectory);
++    }
++    if (!empty($this->config['import'])) {
++      /** @var \Drupal\Core\Extension\ModuleExtensionList $module_list */
++      $module_list = \Drupal::service('extension.list.module');
++      /** @var \Drupal\Core\Extension\ThemeExtensionList $theme_list */
++      $theme_list = \Drupal::service('extension.list.theme');
++      foreach ($this->config['import'] as $extension => $config) {
++        $path = match (TRUE) {
++          $module_list->exists($extension) => $module_list->getPath($extension),
++          $theme_list->exists($extension) => $theme_list->getPath($extension),
++          default => throw new \RuntimeException("$extension is not a theme or module")
++        };
++        $config = (array) ($config === '*' ? NULL : $config);
++        $storages[] = new RecipeExtensionConfigStorage($path, $config);
++      }
++    }
++
++    return RecipeConfigStorageWrapper::createStorageFromArray($storages);
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Recipe/ContentConfigurator.php b/core/lib/Drupal/Core/Recipe/ContentConfigurator.php
+new file mode 100644
+index 0000000000..753ecc16d4
+--- /dev/null
++++ b/core/lib/Drupal/Core/Recipe/ContentConfigurator.php
+@@ -0,0 +1,19 @@
++<?php
++
++namespace Drupal\Core\Recipe;
++
++/**
++ * @internal
++ *   This API is experimental.
++ */
++final class ContentConfigurator {
++
++  /**
++   * @param array $content
++   *   Content options for a recipe.
++   */
++  public function __construct(public readonly array $content) {
++    // @todo https://www.drupal.org/project/distributions_recipes/issues/3292287
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Recipe/InstallConfigurator.php b/core/lib/Drupal/Core/Recipe/InstallConfigurator.php
+new file mode 100644
+index 0000000000..2fd2059e5b
+--- /dev/null
++++ b/core/lib/Drupal/Core/Recipe/InstallConfigurator.php
+@@ -0,0 +1,120 @@
++<?php
++
++namespace Drupal\Core\Recipe;
++
++use Drupal\Component\Assertion\Inspector;
++use Drupal\Core\Extension\Dependency;
++use Drupal\Core\Extension\ModuleExtensionList;
++use Drupal\Core\Extension\ThemeExtensionList;
++
++/**
++ * @internal
++ *   This API is experimental.
++ */
++final class InstallConfigurator {
++
++  /**
++   * The list of modules to install.
++   *
++   * This list is sorted an includes any module dependencies of the provided
++   * extensions.
++   *
++   * @var string[]
++   */
++  public readonly array $modules;
++
++  /**
++   * The list of themes to install.
++   *
++   * This list is sorted an includes any theme dependencies of the provided
++   * extensions.
++   *
++   * @var string[]
++   */
++  public readonly array $themes;
++
++  /**
++   * @param string[] $extensions
++   *   A list of extensions for a recipe to install.
++   * @param \Drupal\Core\Extension\ModuleExtensionList $module_list
++   *   The module list service.
++   * @param \Drupal\Core\Extension\ThemeExtensionList $theme_list
++   *   The theme list service.
++   */
++  public function __construct(array $extensions, ModuleExtensionList $module_list, ThemeExtensionList $theme_list) {
++    assert(Inspector::assertAllStrings($extensions), 'Extension names must be strings.');
++    $extensions = array_map(fn($extension) => Dependency::createFromString($extension)->getName(), $extensions);
++    $extensions = array_combine($extensions, $extensions);
++    $module_data = $module_list->reset()->getList();
++    $theme_data = $theme_list->reset()->getList();
++
++    $modules = array_intersect_key($extensions, $module_data);
++    $themes = array_intersect_key($extensions, $theme_data);
++
++    $missing_extensions = array_diff($extensions, $modules, $themes);
++
++    // Add theme module dependencies.
++    foreach ($themes as $theme => $value) {
++      $modules = array_merge($modules, array_keys($theme_data[$theme]->module_dependencies));
++    }
++
++    // Add modules that other modules depend on.
++    // @todo should recipes do this? I think so. It allows modules to add
++    //   dependencies and recipes continue to work
++    foreach ($modules as $module) {
++      if ($module_data[$module]->requires) {
++        $modules = array_merge($modules, array_keys($module_data[$module]->requires));
++      }
++    }
++
++    // Remove all modules that have been installed already.
++    $modules = array_diff(array_unique($modules), array_keys($module_list->getAllInstalledInfo()));
++    $modules = array_combine($modules, $modules);
++
++    // Create a sortable list of modules.
++    foreach ($modules as $name => $value) {
++      if (isset($module_data[$name])) {
++        $modules[$name] = $module_data[$name]->sort;
++      }
++      else {
++        $missing_extensions[$name] = $name;
++      }
++    }
++
++    // Add any missing base themes to the list of themes to install.
++    foreach ($themes as $theme => $value) {
++      // $theme_data[$theme]->requires contains both theme and module
++      // dependencies keyed by the extension machine names.
++      // $theme_data[$theme]->module_dependencies contains only the module
++      // dependencies keyed by the module extension machine name. Therefore,
++      // we can find the theme dependencies by finding array keys for
++      // 'requires' that are not in $module_dependencies.
++      $theme_dependencies = array_diff_key($theme_data[$theme]->requires, $theme_data[$theme]->module_dependencies);
++      $themes = array_merge($themes, array_keys($theme_dependencies));
++    }
++
++    // Remove all themes that have been installed already.
++    $themes = array_diff(array_unique($themes), array_keys($theme_list->getAllInstalledInfo()));
++    $themes = array_combine($themes, $themes);
++
++    // Create a sortable list of themes.
++    foreach ($themes as $name => $value) {
++      if (isset($theme_data[$name])) {
++        $themes[$name] = $theme_data[$name]->sort;
++      }
++      else {
++        $missing_extensions[$name] = $name;
++      }
++    }
++
++    if (!empty($missing_extensions)) {
++      throw new RecipeMissingExtensionsException(array_values($missing_extensions));
++    }
++
++    arsort($modules);
++    arsort($themes);
++    $this->modules = array_keys($modules);
++    $this->themes = array_keys($themes);
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Recipe/Recipe.php b/core/lib/Drupal/Core/Recipe/Recipe.php
+new file mode 100644
+index 0000000000..ed35e1887d
+--- /dev/null
++++ b/core/lib/Drupal/Core/Recipe/Recipe.php
+@@ -0,0 +1,70 @@
++<?php
++
++namespace Drupal\Core\Recipe;
++
++use Drupal\Core\Serialization\Yaml;
++
++/**
++ * @internal
++ *   This API is experimental.
++ */
++final class Recipe {
++
++  const COMPOSER_PROJECT_TYPE = 'drupal-recipe';
++
++  public function __construct(
++    public readonly string $name,
++    public readonly string $description,
++    public readonly string $type,
++    public readonly RecipeConfigurator $recipes,
++    public readonly InstallConfigurator $install,
++    public readonly ConfigConfigurator $config,
++    public readonly ContentConfigurator $content
++  ) {
++  }
++
++  /**
++   * Creates a recipe object from the provided path.
++   *
++   * @param string $path
++   *   The path to a recipe.
++   *
++   * @return static
++   *   The Recipe object.
++   */
++  public static function createFromDirectory(string $path): static {
++    if (!is_readable($path . '/recipe.yml')) {
++      throw new RecipeFileException("There is no $path/recipe.yml file");
++    }
++
++    $recipe_contents = file_get_contents($path . '/recipe.yml');
++    if (!$recipe_contents) {
++      throw new RecipeFileException("$path/recipe.yml cannot be read");
++    }
++    $recipe_data = Yaml::decode($recipe_contents);
++    // @todo Do we need to improve validation?
++    if (!is_array($recipe_data)) {
++      throw new RecipeFileException("$path/recipe.yml is invalid");
++    }
++    $recipe_data += [
++      'description' => '',
++      'type' => '',
++      'recipes' => [],
++      'install' => [],
++      'config' => [],
++      'content' => [],
++    ];
++
++    if (!isset($recipe_data['name'])) {
++      throw new RecipeFileException("The $path/recipe.yml has no name value.");
++    }
++
++    $recipe_discovery = new RecipeDiscovery([dirname($path)]);
++    $recipes = new RecipeConfigurator($recipe_data['recipes'], $recipe_discovery);
++    $install = new InstallConfigurator($recipe_data['install'], \Drupal::service('extension.list.module'), \Drupal::service('extension.list.theme'));
++    $config = new ConfigConfigurator($recipe_data['config'], $path, \Drupal::service('config.storage'));
++    $content = new ContentConfigurator($recipe_data['content']);
++    return new static($recipe_data['name'], $recipe_data['description'], $recipe_data['type'], $recipes, $install, $config, $content);
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Recipe/RecipeCommand.php b/core/lib/Drupal/Core/Recipe/RecipeCommand.php
+new file mode 100644
+index 0000000000..6b3414aec9
+--- /dev/null
++++ b/core/lib/Drupal/Core/Recipe/RecipeCommand.php
+@@ -0,0 +1,111 @@
++<?php
++
++namespace Drupal\Core\Recipe;
++
++use Drupal\Core\DrupalKernel;
++use Drupal\Core\Site\Settings;
++use Symfony\Component\Console\Command\Command;
++use Symfony\Component\Console\Input\InputArgument;
++use Symfony\Component\Console\Input\InputInterface;
++use Symfony\Component\Console\Output\OutputInterface;
++use Symfony\Component\Console\Style\SymfonyStyle;
++use Symfony\Component\HttpFoundation\Request;
++
++/**
++ * Applies recipe.
++ *
++ * @internal
++ *   This API is experimental.
++ */
++final class RecipeCommand extends Command {
++
++  /**
++   * The class loader.
++   *
++   * @var object
++   */
++  protected $classLoader;
++
++  /**
++   * Constructs a new ServerCommand command.
++   *
++   * @param object $class_loader
++   *   The class loader.
++   */
++  public function __construct($class_loader) {
++    parent::__construct('recipe');
++    $this->classLoader = $class_loader;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  protected function configure(): void {
++    $this
++      ->setDescription('Applies a recipe to a site.')
++      ->addArgument('path', InputArgument::REQUIRED, 'The path to the recipe\'s folder to apply');
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  protected function execute(InputInterface $input, OutputInterface $output): int {
++    $io = new SymfonyStyle($input, $output);
++
++    if (PHP_VERSION_ID < 80100) {
++      $io->error('Recipes require PHP 8.1');
++      return 1;
++    }
++
++    $recipe_path = $input->getArgument('path');
++    if (!is_string($recipe_path) || !is_dir($recipe_path)) {
++      $io->error(sprintf('The supplied path %s is not a directory', $recipe_path));
++    }
++
++    // Recipes have to be applied to installed sites.
++    $container = $this->boot()->getContainer();
++
++    /** @var \Drupal\Core\Config\Checkpoint\CheckpointStorageInterface $checkpoint_storage */
++    $checkpoint_storage = $container->get('config.storage.checkpoint');
++    $recipe = Recipe::createFromDirectory($recipe_path);
++    $checkpoint_storage->checkpoint("Backup before the '$recipe->name' recipe.");
++    RecipeRunner::processRecipe($recipe);
++
++    $io->success(sprintf('%s applied successfully', $recipe->name));
++    return 0;
++  }
++
++  /**
++   * Boots up a Drupal environment.
++   *
++   * @return \Drupal\Core\DrupalKernelInterface
++   *   The Drupal kernel.
++   *
++   * @throws \Exception
++   *   Exception thrown if kernel does not boot.
++   */
++  protected function boot() {
++    $kernel = new DrupalKernel('prod', $this->classLoader, FALSE);
++    $kernel::bootEnvironment();
++    $kernel->setSitePath($this->getSitePath());
++    Settings::initialize($kernel->getAppRoot(), $kernel->getSitePath(), $this->classLoader);
++    $kernel->boot();
++    $kernel->preHandle(Request::createFromGlobals());
++
++    return $kernel;
++  }
++
++  /**
++   * Gets the site path.
++   *
++   * Defaults to 'sites/default'. For testing purposes this can be overridden
++   * using the DRUPAL_DEV_SITE_PATH environment variable.
++   *
++   * @return string
++   *   The site path to use.
++   */
++  protected function getSitePath() {
++    return getenv('DRUPAL_DEV_SITE_PATH') ?: 'sites/default';
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Recipe/RecipeConfigInstaller.php b/core/lib/Drupal/Core/Recipe/RecipeConfigInstaller.php
+new file mode 100644
+index 0000000000..70d6308d22
+--- /dev/null
++++ b/core/lib/Drupal/Core/Recipe/RecipeConfigInstaller.php
+@@ -0,0 +1,63 @@
++<?php
++
++namespace Drupal\Core\Recipe;
++
++use Drupal\Core\Config\ConfigInstaller;
++use Drupal\Core\Config\Entity\ConfigDependencyManager;
++use Drupal\Core\Config\StorageInterface;
++
++/**
++ * Extends the ConfigInstaller service for recipes.
++ *
++ * @internal
++ *   This API is experimental.
++ */
++final class RecipeConfigInstaller extends ConfigInstaller {
++
++  /**
++   * {@inheritdoc}
++   */
++  public function installRecipeConfig(ConfigConfigurator $recipe_config): void {
++    $storage = $recipe_config->getConfigStorage();
++
++    // Build the list of possible configuration to create.
++    $list = $storage->listAll();
++
++    $enabled_extensions = $this->getEnabledExtensions();
++    $existing_config = $this->getActiveStorages()->listAll();
++
++    // Filter the list of configuration to only include configuration that
++    // should be created.
++    $list = array_filter($list, function ($config_name) use ($existing_config) {
++      // Only list configuration that:
++      // - does not already exist
++      return !in_array($config_name, $existing_config);
++    });
++
++    // If there is nothing to do.
++    if (empty($list)) {
++      return;
++    }
++
++    $all_config = array_merge($existing_config, $list);
++    $all_config = array_combine($all_config, $all_config);
++    $config_to_create = $storage->readMultiple($list);
++
++    // Sort $config_to_create in the order of the least dependent first.
++    $dependency_manager = new ConfigDependencyManager();
++    $dependency_manager->setData($config_to_create);
++    $config_to_create = array_merge(array_flip($dependency_manager->sortAll()), $config_to_create);
++
++    foreach ($config_to_create as $config_name => $data) {
++      if (!$this->validateDependencies($config_name, $data, $enabled_extensions, $all_config)) {
++        throw new RecipeUnmetDependenciesException($config_name, sprintf("The configuration '%s' has unmet dependencies", $config_name));
++      }
++    }
++
++    // Create the optional configuration if there is any left after filtering.
++    if (!empty($config_to_create)) {
++      $this->createConfiguration(StorageInterface::DEFAULT_COLLECTION, $config_to_create);
++    }
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Recipe/RecipeConfigStorageWrapper.php b/core/lib/Drupal/Core/Recipe/RecipeConfigStorageWrapper.php
+new file mode 100644
+index 0000000000..d2808d16dd
+--- /dev/null
++++ b/core/lib/Drupal/Core/Recipe/RecipeConfigStorageWrapper.php
+@@ -0,0 +1,156 @@
++<?php
++
++namespace Drupal\Core\Recipe;
++
++use Drupal\Core\Config\NullStorage;
++use Drupal\Core\Config\StorageInterface;
++
++/**
++ * Merges two storages together.
++ *
++ * @internal
++ *   This API is experimental.
++ */
++final class RecipeConfigStorageWrapper implements StorageInterface {
++
++  /**
++   * @param \Drupal\Core\Config\StorageInterface $storageA
++   *   First config storage to wrap.
++   * @param \Drupal\Core\Config\StorageInterface $storageB
++   *   Second config storage to wrap.
++   * @param string $collection
++   *   (optional) The collection to store configuration in. Defaults to the
++   *   default collection.
++   */
++  public function __construct(protected readonly StorageInterface $storageA, protected readonly StorageInterface $storageB, protected readonly string $collection = StorageInterface::DEFAULT_COLLECTION) {
++  }
++
++  /**
++   * Creates a single config storage for an array of storages.
++   *
++   * If the same configuration is contained in multiple storages then the
++   * version returned is from the first storage supplied in the $storages array.
++   *
++   * @param \Drupal\Core\Config\StorageInterface[] $storages
++   *   An array of storages to merge into a single storage.
++   *
++   * @return \Drupal\Core\Config\StorageInterface
++   *   A config storage that represents a merge of all the provided storages.
++   */
++  public static function createStorageFromArray(array $storages): StorageInterface {
++    // If storages is empty use the NullStorage to represent an empty storage.
++    if (empty($storages)) {
++      return new NullStorage();
++    }
++
++    // When there is only one storage there is no point wrapping it.
++    if (count($storages) === 1) {
++      return reset($storages);
++    }
++
++    // Reduce all the storages to a single RecipeConfigStorageWrapper object.
++    // The storages are prioritized in the order they are added to $storages.
++    return array_reduce($storages, fn(StorageInterface $carry, StorageInterface $storage) => new static($carry, $storage), new static(
++      array_shift($storages),
++      array_shift($storages)
++    ));
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function exists($name): bool {
++    return $this->storageA->exists($name) || $this->storageB->exists($name);
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function read($name): array|bool {
++    return $this->storageA->read($name) ?: $this->storageB->read($name);
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function readMultiple(array $names): array {
++    // If both storageA and storageB contain the same configuration, the value
++    // for storageA takes precedence.
++    return array_merge($this->storageB->readMultiple($names), $this->storageA->readMultiple($names));
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function write($name, array $data): bool {
++    throw new \BadMethodCallException();
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function delete($name): bool {
++    throw new \BadMethodCallException();
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function rename($name, $new_name): bool {
++    throw new \BadMethodCallException();
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function encode($data): string {
++    return $this->storageA->encode($data);
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function decode($raw): array {
++    return $this->storageA->decode($raw);
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function listAll($prefix = ''): array {
++    return array_unique(array_merge($this->storageA->listAll($prefix), $this->storageB->listAll($prefix)));
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function deleteAll($prefix = ''): bool {
++    throw new \BadMethodCallException();
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function createCollection($collection): static {
++    return new static(
++      $this->storageA->createCollection($collection),
++      $this->storageB->createCollection($collection),
++      $collection
++    );
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function getAllCollectionNames(): array {
++    return array_unique(array_merge($this->storageA->getAllCollectionNames(), $this->storageB->getAllCollectionNames()));
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function getCollectionName(): string {
++    return $this->collection;
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Recipe/RecipeConfigurator.php b/core/lib/Drupal/Core/Recipe/RecipeConfigurator.php
+new file mode 100644
+index 0000000000..f541675e36
+--- /dev/null
++++ b/core/lib/Drupal/Core/Recipe/RecipeConfigurator.php
+@@ -0,0 +1,24 @@
++<?php
++
++namespace Drupal\Core\Recipe;
++
++/**
++ * @internal
++ *   This API is experimental.
++ */
++final class RecipeConfigurator {
++
++  public readonly array $recipes;
++
++  /**
++   * @param string[] $recipes
++   *   A list of recipes for a recipe to apply. The recipes will be applied in
++   *   the order listed.
++   * @param \Drupal\Core\Recipe\RecipeDiscovery $recipeDiscovery
++   *   Recipe discovery.
++   */
++  public function __construct(array $recipes, RecipeDiscovery $recipeDiscovery) {
++    $this->recipes = array_map([$recipeDiscovery, 'getRecipe'], $recipes);
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Recipe/RecipeDiscovery.php b/core/lib/Drupal/Core/Recipe/RecipeDiscovery.php
+new file mode 100644
+index 0000000000..02e88a6481
+--- /dev/null
++++ b/core/lib/Drupal/Core/Recipe/RecipeDiscovery.php
+@@ -0,0 +1,55 @@
++<?php
++
++namespace Drupal\Core\Recipe;
++
++use Drupal\Component\Assertion\Inspector;
++use Drupal\Core\Site\Settings;
++
++/**
++ * @internal
++ *   This API is experimental.
++ */
++final class RecipeDiscovery {
++
++  /**
++   * Constructs a recipe discovery object.
++   *
++   * @param array $paths
++   *   An array of paths where to search for recipes. The path will be searched
++   *   folders containing a recipe.yml. There will be no traversal further into
++   *   the directory structure.
++   */
++  public function __construct(protected readonly array $paths) {
++    assert(Inspector::assertAllStrings($paths), 'Paths must be strings.');
++  }
++
++  /**
++   * Constructs a RecipeDiscovery object.
++   *
++   * @param string $name
++   *   The machine name of the recipe to find.
++   *
++   * @return \Drupal\Core\Recipe\Recipe
++   *   The recipe object.
++   *
++   * @throws \Drupal\Core\Recipe\UnknownRecipeException
++   *   Thrown when the recipe cannot be found.
++   */
++  public function getRecipe(string $name): Recipe {
++    $paths = [
++      ...$this->paths,
++      DRUPAL_ROOT . '/recipes',
++      DRUPAL_ROOT . '/core/recipes',
++    ];
++    if (Settings::get('extension_discovery_scan_tests')) {
++      $paths[] = DRUPAL_ROOT . '/core/tests/fixtures/recipes';
++    }
++    foreach ($paths as $path) {
++      if (file_exists($path . DIRECTORY_SEPARATOR . $name . DIRECTORY_SEPARATOR . 'recipe.yml')) {
++        return Recipe::createFromDirectory($path . DIRECTORY_SEPARATOR . $name);
++      }
++    }
++    throw new UnknownRecipeException($name, $this->paths, sprintf("Can not find the %s recipe, search paths: %s", $name, implode(', ', $this->paths)));
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Recipe/RecipeExtensionConfigStorage.php b/core/lib/Drupal/Core/Recipe/RecipeExtensionConfigStorage.php
+new file mode 100644
+index 0000000000..4dfaf80d3e
+--- /dev/null
++++ b/core/lib/Drupal/Core/Recipe/RecipeExtensionConfigStorage.php
+@@ -0,0 +1,144 @@
++<?php
++
++namespace Drupal\Core\Recipe;
++
++use Drupal\Core\Config\FileStorage;
++use Drupal\Core\Config\StorageInterface;
++
++/**
++ * Allows the recipe to select configuration from the module.
++ *
++ * @internal
++ *   This API is experimental.
++ */
++final class RecipeExtensionConfigStorage implements StorageInterface {
++
++  protected readonly StorageInterface $storage;
++
++  /**
++   * @param string $extensionPath
++   *   The path extension to read configuration from
++   * @param array $configNames
++   *   The list of config to read from the extension. An empty array means all
++   *   configuration.
++   * @param string $collection
++   *   (optional) The collection to store configuration in. Defaults to the
++   *   default collection.
++   */
++  public function __construct(protected readonly string $extensionPath, protected readonly array $configNames, protected readonly string $collection = StorageInterface::DEFAULT_COLLECTION) {
++    $this->storage = new RecipeConfigStorageWrapper(
++      new FileStorage($this->extensionPath . '/config/install', $this->collection),
++      new FileStorage($this->extensionPath . '/config/optional', $this->collection),
++      $collection
++    );
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function exists($name): bool {
++    if (!empty($this->configNames) && !in_array($name, $this->configNames, TRUE)) {
++      return FALSE;
++    }
++    return $this->storage->exists($name);
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function read($name): array|bool {
++    if (!empty($this->configNames) && !in_array($name, $this->configNames, TRUE)) {
++      return FALSE;
++    }
++    return $this->storage->read($name);
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function readMultiple(array $names): array {
++    if (!empty($this->configNames)) {
++      $names = array_intersect($this->configNames, $names);
++    }
++    return $this->storage->readMultiple($names);
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function write($name, array $data): bool {
++    throw new \BadMethodCallException();
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function delete($name): bool {
++    throw new \BadMethodCallException();
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function rename($name, $new_name): bool {
++    throw new \BadMethodCallException();
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function encode($data): string {
++    return $this->storage->encode($data);
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function decode($raw): array {
++    return $this->storage->decode($raw);
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function listAll($prefix = ''): array {
++    $names = $this->storage->listAll($prefix);
++    if (!empty($this->configNames)) {
++      $names = array_intersect($this->configNames, $names);
++    }
++    return $names;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function deleteAll($prefix = ''): bool {
++    throw new \BadMethodCallException();
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function createCollection($collection): static {
++    return new static(
++      $this->extensionPath,
++      $this->configNames,
++      $collection
++    );
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function getAllCollectionNames(): array {
++    return $this->storage->getAllCollectionNames();
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function getCollectionName(): string {
++    return $this->collection;
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Recipe/RecipeFileException.php b/core/lib/Drupal/Core/Recipe/RecipeFileException.php
+new file mode 100644
+index 0000000000..e3f6cffccf
+--- /dev/null
++++ b/core/lib/Drupal/Core/Recipe/RecipeFileException.php
+@@ -0,0 +1,11 @@
++<?php
++
++namespace Drupal\Core\Recipe;
++
++/**
++ * @internal
++ *   This API is experimental.
++ */
++final class RecipeFileException extends \RuntimeException {
++
++}
+diff --git a/core/lib/Drupal/Core/Recipe/RecipeMissingExtensionsException.php b/core/lib/Drupal/Core/Recipe/RecipeMissingExtensionsException.php
+new file mode 100644
+index 0000000000..ebef022987
+--- /dev/null
++++ b/core/lib/Drupal/Core/Recipe/RecipeMissingExtensionsException.php
+@@ -0,0 +1,37 @@
++<?php
++
++namespace Drupal\Core\Recipe;
++
++use Drupal\Component\Assertion\Inspector;
++
++/**
++ * Exception thrown when recipes contain or depend on missing extensions.
++ *
++ * @internal
++ *   This API is experimental.
++ */
++final class RecipeMissingExtensionsException extends \RuntimeException {
++
++  /**
++   * Constructs a RecipeMissingExtensionsException.
++   *
++   * @param array $extensions
++   *   The list of missing extensions.
++   * @param string $message
++   *   [optional] The Exception message to throw.
++   * @param int $code
++   *   [optional] The Exception code.
++   * @param null|\Throwable $previous
++   *   [optional] The previous throwable used for the exception chaining.
++   */
++  public function __construct(public readonly array $extensions, string $message = "", int $code = 0, ?\Throwable $previous = NULL) {
++    assert(Inspector::assertAllStrings($extensions), 'Extension names must be strings.');
++    if (!$message) {
++      $sorted = $this->extensions;
++      sort($sorted);
++      $message = sprintf("The following extensions are missing and are required for this recipe: %s", implode(", ", $sorted));
++    }
++    parent::__construct($message, $code, $previous);
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Recipe/RecipeOverrideConfigStorage.php b/core/lib/Drupal/Core/Recipe/RecipeOverrideConfigStorage.php
+new file mode 100644
+index 0000000000..02cdca54c2
+--- /dev/null
++++ b/core/lib/Drupal/Core/Recipe/RecipeOverrideConfigStorage.php
+@@ -0,0 +1,131 @@
++<?php
++
++namespace Drupal\Core\Recipe;
++
++use Drupal\Core\Config\StorageInterface;
++
++/**
++ * Wraps a config storage to allow recipe provided configuration to override it.
++ *
++ * @internal
++ *   This API is experimental.
++ */
++final class RecipeOverrideConfigStorage implements StorageInterface {
++
++  /**
++   * @param \Drupal\Core\Config\StorageInterface $recipeStorage
++   *   The recipe's configuration storage.
++   * @param \Drupal\Core\Config\StorageInterface $wrappedStorage
++   *   The storage to override.
++   * @param string $collection
++   *   (optional) The collection to store configuration in. Defaults to the
++   *   default collection.
++   */
++  public function __construct(protected readonly StorageInterface $recipeStorage, protected readonly StorageInterface $wrappedStorage, protected readonly string $collection = StorageInterface::DEFAULT_COLLECTION) {
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function exists($name): bool {
++    return $this->wrappedStorage->exists($name);
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function read($name): array|bool {
++    if ($this->wrappedStorage->exists($name) && $this->recipeStorage->exists($name)) {
++      return $this->recipeStorage->read($name);
++    }
++    return $this->wrappedStorage->read($name);
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function readMultiple(array $names): array {
++    $data = $this->wrappedStorage->readMultiple($names);
++    foreach ($data as $name => $value) {
++      if ($this->recipeStorage->exists($name)) {
++        $data[$name] = $this->recipeStorage->read($name);
++      }
++    }
++    return $data;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function write($name, array $data): bool {
++    throw new \BadMethodCallException();
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function delete($name): bool {
++    throw new \BadMethodCallException();
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function rename($name, $new_name): bool {
++    throw new \BadMethodCallException();
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function encode($data): string {
++    return $this->wrappedStorage->encode($data);
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function decode($raw): array {
++    return $this->wrappedStorage->decode($raw);
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function listAll($prefix = ''): array {
++    return $this->wrappedStorage->listAll($prefix);
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function deleteAll($prefix = ''): bool {
++    throw new \BadMethodCallException();
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function createCollection($collection): static {
++    return new static(
++      $this->recipeStorage->createCollection($collection),
++      $this->wrappedStorage->createCollection($collection),
++      $collection
++    );
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function getAllCollectionNames(): array {
++    return $this->wrappedStorage->getAllCollectionNames();
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function getCollectionName(): string {
++    return $this->collection;
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Recipe/RecipePreExistingConfigException.php b/core/lib/Drupal/Core/Recipe/RecipePreExistingConfigException.php
+new file mode 100644
+index 0000000000..ce0bd543bc
+--- /dev/null
++++ b/core/lib/Drupal/Core/Recipe/RecipePreExistingConfigException.php
+@@ -0,0 +1,26 @@
++<?php
++
++namespace Drupal\Core\Recipe;
++
++/**
++ * Exception thrown when a recipe has configuration that exists already.
++ */
++class RecipePreExistingConfigException extends \RuntimeException {
++
++  /**
++   * Constructs a RecipePreExistingConfigException.
++   *
++   * @param string $configName
++   *   The configuration name that has missing dependencies.
++   * @param string $message
++   *   [optional] The Exception message to throw.
++   * @param int $code
++   *   [optional] The Exception code.
++   * @param null|\Throwable $previous
++   *   [optional] The previous throwable used for the exception chaining.
++   */
++  public function __construct(public readonly string $configName, string $message = "", int $code = 0, ?\Throwable $previous = NULL) {
++    parent::__construct($message, $code, $previous);
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Recipe/RecipeRunner.php b/core/lib/Drupal/Core/Recipe/RecipeRunner.php
+new file mode 100644
+index 0000000000..5670c1f871
+--- /dev/null
++++ b/core/lib/Drupal/Core/Recipe/RecipeRunner.php
+@@ -0,0 +1,124 @@
++<?php
++
++namespace Drupal\Core\Recipe;
++
++use Drupal\Core\Config\FileStorage;
++use Drupal\Core\Config\InstallStorage;
++use Drupal\Core\Config\StorageInterface;
++
++/**
++ * Applies a recipe.
++ *
++ * This class currently static and use \Drupal::service() in order to put off
++ * having to solve issues caused by container rebuilds during module install and
++ * configuration import.
++ *
++ * @internal
++ *   This API is experimental.
++ */
++final class RecipeRunner {
++
++  /**
++   * @param \Drupal\Core\Recipe\Recipe $recipe
++   *   The recipe to apply.
++   */
++  public static function processRecipe(Recipe $recipe): void {
++    static::processRecipes($recipe->recipes);
++    static::processInstall($recipe->install, $recipe->config->getConfigStorage());
++    static::processConfiguration($recipe->config);
++    static::processContent($recipe->content);
++  }
++
++  /**
++   * Applies any recipes listed by the recipe.
++   *
++   * @param \Drupal\Core\Recipe\RecipeConfigurator $recipes
++   *   The list of recipes to apply.
++   */
++  protected static function processRecipes(RecipeConfigurator $recipes): void {
++    foreach ($recipes->recipes as $recipe) {
++      static::processRecipe($recipe);
++    }
++  }
++
++  /**
++   * Installs the extensions.
++   *
++   * @param \Drupal\Core\Recipe\InstallConfigurator $install
++   *   The list of extensions to install.
++   * @param \Drupal\Core\Config\StorageInterface $recipeConfigStorage
++   *   The recipe's configuration storage. Used to override extension provided
++   *   configuration.
++   */
++  protected static function processInstall(InstallConfigurator $install, StorageInterface $recipeConfigStorage): void {
++    foreach ($install->modules as $name) {
++      // Disable configuration entity install but use the config directory from
++      // the module.
++      \Drupal::service('config.installer')->setSyncing(TRUE);
++      $default_install_path = \Drupal::service('extension.list.module')->get($name)->getPath() . '/' . InstallStorage::CONFIG_INSTALL_DIRECTORY;
++      // Allow the recipe to override simple configuration from the module.
++      $storage = new RecipeOverrideConfigStorage(
++        $recipeConfigStorage,
++        new FileStorage($default_install_path, StorageInterface::DEFAULT_COLLECTION)
++      );
++      \Drupal::service('config.installer')->setSourceStorage($storage);
++
++      \Drupal::service('module_installer')->install([$name]);
++      \Drupal::service('config.installer')->setSyncing(FALSE);
++    }
++
++    // Themes can depend on modules so have to be installed after modules.
++    foreach ($install->themes as $name) {
++      // Disable configuration entity install.
++      \Drupal::service('config.installer')->setSyncing(TRUE);
++      $default_install_path = \Drupal::service('extension.list.theme')->get($name)->getPath() . '/' . InstallStorage::CONFIG_INSTALL_DIRECTORY;
++      // Allow the recipe to override simple configuration from the theme.
++      $storage = new RecipeOverrideConfigStorage(
++        $recipeConfigStorage,
++        new FileStorage($default_install_path, StorageInterface::DEFAULT_COLLECTION)
++      );
++      \Drupal::service('config.installer')->setSourceStorage($storage);
++
++      \Drupal::service('theme_installer')->install([$name]);
++      \Drupal::service('config.installer')->setSyncing(FALSE);
++    }
++  }
++
++  /**
++   * Creates configuration and applies configuration actions.
++   *
++   * @param \Drupal\Core\Recipe\ConfigConfigurator $config
++   *   The config configurator from the recipe.
++   */
++  protected static function processConfiguration(ConfigConfigurator $config): void {
++    // @todo sort out this monstrosity.
++    $config_installer = new RecipeConfigInstaller(
++      \Drupal::service('config.factory'),
++      \Drupal::service('config.storage'),
++      \Drupal::service('config.typed'),
++      \Drupal::service('config.manager'),
++      \Drupal::service('event_dispatcher'),
++      NULL,
++      \Drupal::service('extension.path.resolver'));
++
++    // Create configuration that is either supplied by the recipe or listed in
++    // the config.import section that does not exist.
++    $config_installer->installRecipeConfig($config);
++
++    if (!empty($config->config['actions'])) {
++      // Process the actions.
++      /** @var \Drupal\Core\Config\Action\ConfigActionManager $config_action_manager */
++      $config_action_manager = \Drupal::service('plugin.manager.config_action');
++      foreach ($config->config['actions'] as $config_name => $actions) {
++        foreach ($actions as $action_id => $data) {
++          $config_action_manager->applyAction($action_id, $config_name, $data);
++        }
++      }
++    }
++  }
++
++  protected static function processContent(ContentConfigurator $content): void {
++    // @todo https://www.drupal.org/project/distributions_recipes/issues/3292287
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Recipe/RecipeUnmetDependenciesException.php b/core/lib/Drupal/Core/Recipe/RecipeUnmetDependenciesException.php
+new file mode 100644
+index 0000000000..71fcdc6b2a
+--- /dev/null
++++ b/core/lib/Drupal/Core/Recipe/RecipeUnmetDependenciesException.php
+@@ -0,0 +1,29 @@
++<?php
++
++namespace Drupal\Core\Recipe;
++
++/**
++ * Exception thrown when a recipe has configuration with unmet dependencies.
++ *
++ * @internal
++ *   This API is experimental.
++ */
++final class RecipeUnmetDependenciesException extends \RuntimeException {
++
++  /**
++   * Constructs a RecipeUnmetDependenciesException.
++   *
++   * @param string $configName
++   *   The configuration name that has missing dependencies.
++   * @param string $message
++   *   [optional] The Exception message to throw.
++   * @param int $code
++   *   [optional] The Exception code.
++   * @param null|\Throwable $previous
++   *   [optional] The previous throwable used for the exception chaining.
++   */
++  public function __construct(public readonly string $configName, string $message = "", int $code = 0, ?\Throwable $previous = NULL) {
++    parent::__construct($message, $code, $previous);
++  }
++
++}
+diff --git a/core/lib/Drupal/Core/Recipe/UnknownRecipeException.php b/core/lib/Drupal/Core/Recipe/UnknownRecipeException.php
+new file mode 100644
+index 0000000000..9351ba4dc6
+--- /dev/null
++++ b/core/lib/Drupal/Core/Recipe/UnknownRecipeException.php
+@@ -0,0 +1,29 @@
++<?php
++
++namespace Drupal\Core\Recipe;
++
++/**
++ * Exception thrown when recipe is can not be found.
++ *
++ * @internal
++ *   This API is experimental.
++ */
++final class UnknownRecipeException extends \RuntimeException {
++
++  /**
++   * @param string $recipe
++   *   The recipe's name.
++   * @param array $searchPaths
++   *   The paths searched for the recipe.
++   * @param string $message
++   *   (optional) The exception message.
++   * @param int $code
++   *   (optional) The exception code.
++   * @param \Throwable|null $previous
++   *   (optional) The previous exception.
++   */
++  public function __construct(public readonly string $recipe, public readonly array $searchPaths, string $message = "", int $code = 0, ?\Throwable $previous = NULL) {
++    parent::__construct($message, $code, $previous);
++  }
++
++}
+diff --git a/core/modules/config/tests/config_action_duplicate_test/config_action_duplicate_test.info.yml b/core/modules/config/tests/config_action_duplicate_test/config_action_duplicate_test.info.yml
+new file mode 100644
+index 0000000000..2f1dd51d4c
+--- /dev/null
++++ b/core/modules/config/tests/config_action_duplicate_test/config_action_duplicate_test.info.yml
+@@ -0,0 +1,4 @@
++name: 'Config action duplicate test'
++type: module
++package: Testing
++version: VERSION
+diff --git a/core/modules/config/tests/config_action_duplicate_test/src/Plugin/ConfigAction/DuplicateConfigAction.php b/core/modules/config/tests/config_action_duplicate_test/src/Plugin/ConfigAction/DuplicateConfigAction.php
+new file mode 100644
+index 0000000000..d19474c620
+--- /dev/null
++++ b/core/modules/config/tests/config_action_duplicate_test/src/Plugin/ConfigAction/DuplicateConfigAction.php
+@@ -0,0 +1,26 @@
++<?php
++
++namespace Drupal\config_duplicate_action_test\Plugin\ConfigAction;
++
++use Drupal\Core\Config\Action\ConfigActionPluginInterface;
++
++/**
++ * @ConfigAction(
++ *   id = "config_action_duplicate_test:config_test.dynamic:setProtectedProperty",
++ *   admin_label = @Translation("A duplicate config action"),
++ *   entity_types = {
++ *     "config_test"
++ *   }
++ * )
++ */
++final class DuplicateConfigAction implements ConfigActionPluginInterface {
++
++  /**
++   * {@inheritdoc}
++   */
++  public function apply(string $configName, mixed $value): void {
++    // This method should never be called.
++    throw new \BadMethodCallException();
++  }
++
++}
+diff --git a/core/modules/config/tests/config_collection_install_test/config_collection_install_test.services.yml b/core/modules/config/tests/config_collection_install_test/config_collection_install_test.services.yml
+index 3ee0d2360d..6526996af2 100644
+--- a/core/modules/config/tests/config_collection_install_test/config_collection_install_test.services.yml
++++ b/core/modules/config/tests/config_collection_install_test/config_collection_install_test.services.yml
+@@ -1,5 +1,5 @@
+ services:
+-  config_events_test.event_subscriber:
++  config_collection_install_test.event_subscriber:
+     class: Drupal\config_collection_install_test\EventSubscriber
+     arguments: ['@state']
+     tags:
+diff --git a/core/modules/config/tests/config_collection_install_test/src/EventSubscriber.php b/core/modules/config/tests/config_collection_install_test/src/EventSubscriber.php
+index 7f6a60f237..bc907ce3cd 100644
+--- a/core/modules/config/tests/config_collection_install_test/src/EventSubscriber.php
++++ b/core/modules/config/tests/config_collection_install_test/src/EventSubscriber.php
+@@ -2,8 +2,8 @@
+ 
+ namespace Drupal\config_collection_install_test;
+ 
++use Drupal\Core\Config\ConfigCollectionEvents;
+ use Drupal\Core\Config\ConfigCollectionInfo;
+-use Drupal\Core\Config\ConfigEvents;
+ use Drupal\Core\State\StateInterface;
+ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+ 
+@@ -27,7 +27,7 @@ public function __construct(StateInterface $state) {
+   }
+ 
+   /**
+-   * Reacts to the ConfigEvents::COLLECTION_INFO event.
++   * Reacts to the ConfigCollectionEvents::COLLECTION_INFO event.
+    *
+    * @param \Drupal\Core\Config\ConfigCollectionInfo $collection_info
+    *   The configuration collection info event.
+@@ -43,7 +43,7 @@ public function addCollections(ConfigCollectionInfo $collection_info) {
+    * {@inheritdoc}
+    */
+   public static function getSubscribedEvents(): array {
+-    $events[ConfigEvents::COLLECTION_INFO][] = ['addCollections'];
++    $events[ConfigCollectionEvents::COLLECTION_INFO][] = ['addCollections'];
+     return $events;
+   }
+ 
+diff --git a/core/modules/config/tests/config_events_test/src/EventSubscriber.php b/core/modules/config/tests/config_events_test/src/EventSubscriber.php
+index 8a79b8b606..bca146547b 100644
+--- a/core/modules/config/tests/config_events_test/src/EventSubscriber.php
++++ b/core/modules/config/tests/config_events_test/src/EventSubscriber.php
+@@ -2,6 +2,7 @@
+ 
+ namespace Drupal\config_events_test;
+ 
++use Drupal\Core\Config\ConfigCollectionEvents;
+ use Drupal\Core\Config\ConfigCrudEvent;
+ use Drupal\Core\Config\ConfigEvents;
+ use Drupal\Core\State\StateInterface;
+@@ -31,17 +32,24 @@ public function __construct(StateInterface $state) {
+    *
+    * @param \Drupal\Core\Config\ConfigCrudEvent $event
+    *   The configuration event.
+-   * @param string $name
++   * @param string $event_name
+    *   The event name.
+    */
+-  public function configEventRecorder(ConfigCrudEvent $event, $name) {
++  public function configEventRecorder(ConfigCrudEvent $event, $event_name) {
+     $config = $event->getConfig();
+-    $this->state->set('config_events_test.event', [
+-      'event_name' => $name,
++    $event_info = [
++      'event_name' => $event_name,
+       'current_config_data' => $config->get(),
+       'original_config_data' => $config->getOriginal(),
+       'raw_config_data' => $config->getRawData(),
+-    ]);
++    ];
++    $this->state->set('config_events_test.event', $event_info);
++
++    // Record all events that occur.
++    $all_events = $this->state->get('config_events_test.all_events', []);
++    $config_name = $config->getName();
++    $all_events[$event_name][$config_name][] = $event_info;
++    $this->state->set('config_events_test.all_events', $all_events);
+   }
+ 
+   /**
+@@ -51,6 +59,9 @@ public static function getSubscribedEvents(): array {
+     $events[ConfigEvents::SAVE][] = ['configEventRecorder'];
+     $events[ConfigEvents::DELETE][] = ['configEventRecorder'];
+     $events[ConfigEvents::RENAME][] = ['configEventRecorder'];
++    $events[ConfigCollectionEvents::SAVE_IN_COLLECTION][] = ['configEventRecorder'];
++    $events[ConfigCollectionEvents::DELETE_IN_COLLECTION][] = ['configEventRecorder'];
++    $events[ConfigCollectionEvents::RENAME_IN_COLLECTION][] = ['configEventRecorder'];
+     return $events;
+   }
+ 
+diff --git a/core/modules/config/tests/config_test/config/schema/config_test.schema.yml b/core/modules/config/tests/config_test/config/schema/config_test.schema.yml
+index 2a707facb0..b6b59ec5e3 100644
+--- a/core/modules/config/tests/config_test/config/schema/config_test.schema.yml
++++ b/core/modules/config/tests/config_test/config/schema/config_test.schema.yml
+@@ -24,6 +24,9 @@ config_test_dynamic:
+     protected_property:
+       type: string
+       label: 'Protected property'
++    array_property:
++      type: ignore
++      label: 'Array property'
+ 
+ config_test.dynamic.*:
+   type: config_test_dynamic
+diff --git a/core/modules/config/tests/config_test/config_test.module b/core/modules/config/tests/config_test/config_test.module
+index ac06237e35..2464708891 100644
+--- a/core/modules/config/tests/config_test/config_test.module
++++ b/core/modules/config/tests/config_test/config_test.module
+@@ -40,4 +40,8 @@ function config_test_entity_type_alter(array &$entity_types) {
+   if (\Drupal::service('state')->get('config_test.lookup_keys', FALSE)) {
+     $entity_types['config_test']->set('lookup_keys', ['uuid', 'style']);
+   }
++
++  if (\Drupal::service('state')->get('config_test.class_override', FALSE)) {
++    $entity_types['config_test']->setClass(\Drupal::service('state')->get('config_test.class_override'));
++  }
+ }
+diff --git a/core/modules/config/tests/config_test/src/ConfigActionErrorEntity/DuplicatePluralizedMethodName.php b/core/modules/config/tests/config_test/src/ConfigActionErrorEntity/DuplicatePluralizedMethodName.php
+new file mode 100644
+index 0000000000..b51e41af5d
+--- /dev/null
++++ b/core/modules/config/tests/config_test/src/ConfigActionErrorEntity/DuplicatePluralizedMethodName.php
+@@ -0,0 +1,17 @@
++<?php
++
++namespace Drupal\config_test\ConfigActionErrorEntity;
++
++use Drupal\config_test\Entity\ConfigTest;
++use Drupal\Core\Config\Action\Attribute\ActionMethod;
++
++/**
++ * Test entity class.
++ */
++class DuplicatePluralizedMethodName extends ConfigTest {
++
++  #[ActionMethod(pluralize: 'testMethod')]
++  public function testMethod() {
++  }
++
++}
+diff --git a/core/modules/config/tests/config_test/src/ConfigActionErrorEntity/DuplicatePluralizedOtherMethodName.php b/core/modules/config/tests/config_test/src/ConfigActionErrorEntity/DuplicatePluralizedOtherMethodName.php
+new file mode 100644
+index 0000000000..98c5d07559
+--- /dev/null
++++ b/core/modules/config/tests/config_test/src/ConfigActionErrorEntity/DuplicatePluralizedOtherMethodName.php
+@@ -0,0 +1,21 @@
++<?php
++
++namespace Drupal\config_test\ConfigActionErrorEntity;
++
++use Drupal\config_test\Entity\ConfigTest;
++use Drupal\Core\Config\Action\Attribute\ActionMethod;
++
++/**
++ * Test entity class.
++ */
++class DuplicatePluralizedOtherMethodName extends ConfigTest {
++
++  #[ActionMethod(pluralize: 'testMethod2')]
++  public function testMethod() {
++  }
++
++  #[ActionMethod()]
++  public function testMethod2() {
++  }
++
++}
+diff --git a/core/modules/config/tests/config_test/src/Entity/ConfigQueryTest.php b/core/modules/config/tests/config_test/src/Entity/ConfigQueryTest.php
+index 6b9e8007db..b461828a63 100644
+--- a/core/modules/config/tests/config_test/src/Entity/ConfigQueryTest.php
++++ b/core/modules/config/tests/config_test/src/Entity/ConfigQueryTest.php
+@@ -46,4 +46,13 @@ class ConfigQueryTest extends ConfigTest {
+    */
+   public $array = [];
+ 
++  /**
++   * {@inheritdoc}
++   */
++  public function concatProtectedProperty(string $value1, string $value2): static {
++    // This method intentionally does not have the config action attribute to
++    // ensure it is still discovered.
++    return parent::concatProtectedProperty($value1, $value2);
++  }
++
+ }
+diff --git a/core/modules/config/tests/config_test/src/Entity/ConfigTest.php b/core/modules/config/tests/config_test/src/Entity/ConfigTest.php
+index 30a7a3526d..0ff6bdd5a8 100644
+--- a/core/modules/config/tests/config_test/src/Entity/ConfigTest.php
++++ b/core/modules/config/tests/config_test/src/Entity/ConfigTest.php
+@@ -2,10 +2,12 @@
+ 
+ namespace Drupal\config_test\Entity;
+ 
++use Drupal\Core\Config\Action\Attribute\ActionMethod;
+ use Drupal\Core\Config\Entity\ConfigEntityBase;
+ use Drupal\config_test\ConfigTestInterface;
+ use Drupal\Core\Config\Entity\ConfigEntityInterface;
+ use Drupal\Core\Entity\EntityStorageInterface;
++use Drupal\Core\StringTranslation\TranslatableMarkup;
+ 
+ /**
+  * Defines the ConfigTest configuration entity.
+@@ -36,6 +38,7 @@
+  *     "size",
+  *     "size_value",
+  *     "protected_property",
++ *     "array_property",
+  *   },
+  *   links = {
+  *     "edit-form" = "/admin/structure/config_test/manage/{config_test}",
+@@ -83,6 +86,13 @@ class ConfigTest extends ConfigEntityBase implements ConfigTestInterface {
+    */
+   protected $protected_property;
+ 
++  /**
++   * An array property of the configuration entity.
++   *
++   * @var array
++   */
++  protected array $array_property = [];
++
+   /**
+    * {@inheritdoc}
+    */
+@@ -188,4 +198,130 @@ public function isInstallable() {
+     return $this->id != 'isinstallable' || \Drupal::state()->get('config_test.isinstallable');
+   }
+ 
++  /**
++   * Sets the protected property value.
++   *
++   * @param $value
++   *   The value to set.
++   *
++   * @return $this
++   *   The config entity.
++   */
++  #[ActionMethod(pluralize: FALSE)]
++  public function setProtectedProperty(string $value): static {
++    $this->protected_property = $value;
++    return $this;
++  }
++
++  /**
++   * Gets the protected property value.
++   *
++   * @return string
++   *   The protected property value.
++   */
++  public function getProtectedProperty(): string {
++    return $this->protected_property;
++  }
++
++  /**
++   * Concatenates the two params and sets the protected property value.
++   *
++   * @param $value1
++   *   The first value to concatenate.
++   * @param $value2
++   *   The second value to concatenate.
++   *
++   * @return $this
++   *   The config entity.
++   */
++  #[ActionMethod()]
++  public function concatProtectedProperty(string $value1, string $value2): static {
++    $this->protected_property = $value1 . $value2;
++    return $this;
++  }
++
++  /**
++   * Concatenates up to two params and sets the protected property value.
++   *
++   * @param $value1
++   *   The first value to concatenate.
++   * @param $value2
++   *   (optional) The second value to concatenate. Defaults to ''.
++   *
++   * @return $this
++   *   The config entity.
++   */
++  #[ActionMethod(pluralize: FALSE)]
++  public function concatProtectedPropertyOptional(string $value1, string $value2 = ''): static {
++    $this->protected_property = $value1 . $value2;
++    return $this;
++  }
++
++  /**
++   * Appends to protected property.
++   *
++   * @param $value
++   *   The value to append.
++   *
++   * @return $this
++   *   The config entity.
++   */
++  #[ActionMethod()]
++  public function append(string $value): static {
++    $this->protected_property .= $value;
++    return $this;
++  }
++
++  /**
++   * Sets the protected property to a default value.
++   *
++   * @return $this
++   *   The config entity.
++   */
++  #[ActionMethod(pluralize: FALSE, adminLabel: new TranslatableMarkup('Set default name'))]
++  public function defaultProtectedProperty(): static {
++    $this->protected_property = 'Set by method';
++    return $this;
++  }
++
++  /**
++   * Adds a value to the array property.
++   *
++   * @param mixed $value
++   *   The value to add.
++   *
++   * @return $this
++   *   The config entity.
++   */
++  #[ActionMethod(pluralize: 'addToArrayMultipleTimes')]
++  public function addToArray(mixed $value): static {
++    $this->array_property[] = $value;
++    return $this;
++  }
++
++  /**
++   * Gets the array property value.
++   *
++   * @return array
++   *   The array property value.
++   */
++  public function getArrayProperty(): array {
++    return $this->array_property;
++  }
++
++  /**
++   * Sets the array property.
++   *
++   * @param $value
++   *   The value to set.
++   *
++   * @return $this
++   *   The config entity.
++   */
++  #[ActionMethod(pluralize: FALSE)]
++  public function setArray(array $value): static {
++    $this->array_property = $value;
++    return $this;
++  }
++
+ }
+diff --git a/core/modules/filter/src/Entity/FilterFormat.php b/core/modules/filter/src/Entity/FilterFormat.php
+index b47ed360cd..17da5a274f 100644
+--- a/core/modules/filter/src/Entity/FilterFormat.php
++++ b/core/modules/filter/src/Entity/FilterFormat.php
+@@ -3,9 +3,11 @@
+ namespace Drupal\filter\Entity;
+ 
+ use Drupal\Component\Plugin\PluginInspectionInterface;
++use Drupal\Core\Config\Action\Attribute\ActionMethod;
+ use Drupal\Core\Config\Entity\ConfigEntityBase;
+ use Drupal\Core\Entity\EntityWithPluginCollectionInterface;
+ use Drupal\Core\Entity\EntityStorageInterface;
++use Drupal\Core\StringTranslation\TranslatableMarkup;
+ use Drupal\filter\FilterFormatInterface;
+ use Drupal\filter\FilterPluginCollection;
+ use Drupal\filter\Plugin\FilterInterface;
+@@ -160,6 +162,7 @@ public function getPluginCollections() {
+   /**
+    * {@inheritdoc}
+    */
++  #[ActionMethod(adminLabel: new TranslatableMarkup('Sets configuration for a filter plugin'))]
+   public function setFilterConfig($instance_id, array $configuration) {
+     $this->filters[$instance_id] = $configuration;
+     if (isset($this->filterCollection)) {
+diff --git a/core/modules/language/src/Config/LanguageConfigOverride.php b/core/modules/language/src/Config/LanguageConfigOverride.php
+index 3b3b4da3c6..e55425d233 100644
+--- a/core/modules/language/src/Config/LanguageConfigOverride.php
++++ b/core/modules/language/src/Config/LanguageConfigOverride.php
+@@ -3,6 +3,8 @@
+ namespace Drupal\language\Config;
+ 
+ use Drupal\Core\Cache\Cache;
++use Drupal\Core\Config\ConfigCollectionEvents;
++use Drupal\Core\Config\ConfigCrudEvent;
+ use Drupal\Core\Config\StorableConfigBase;
+ use Drupal\Core\Config\StorageInterface;
+ use Drupal\Core\Config\TypedConfigManagerInterface;
+@@ -62,6 +64,11 @@ public function save($has_trusted_data = FALSE) {
+     // an update of configuration, but only for a specific language.
+     Cache::invalidateTags($this->getCacheTags());
+     $this->isNew = FALSE;
++    // Dispatch configuration override event as detailed in
++    // \Drupal\Core\Config\ConfigFactoryOverrideInterface::createConfigObject().
++    $this->eventDispatcher->dispatch(new ConfigCrudEvent($this), ConfigCollectionEvents::SAVE_IN_COLLECTION);
++    // Dispatch an event specifically for language configuration override
++    // changes.
+     $this->eventDispatcher->dispatch(new LanguageConfigOverrideCrudEvent($this), LanguageConfigOverrideEvents::SAVE_OVERRIDE);
+     $this->originalData = $this->data;
+     return $this;
+@@ -75,6 +82,11 @@ public function delete() {
+     $this->storage->delete($this->name);
+     Cache::invalidateTags($this->getCacheTags());
+     $this->isNew = TRUE;
++    // Dispatch configuration override event as detailed in
++    // \Drupal\Core\Config\ConfigFactoryOverrideInterface::createConfigObject().
++    $this->eventDispatcher->dispatch(new ConfigCrudEvent($this), ConfigCollectionEvents::DELETE_IN_COLLECTION);
++    // Dispatch an event specifically for language configuration override
++    // changes.
+     $this->eventDispatcher->dispatch(new LanguageConfigOverrideCrudEvent($this), LanguageConfigOverrideEvents::DELETE_OVERRIDE);
+     $this->originalData = $this->data;
+     return $this;
+diff --git a/core/modules/language/tests/language_events_test/config/schema/config_events_test.schema.yml b/core/modules/language/tests/language_events_test/config/schema/config_events_test.schema.yml
+new file mode 100644
+index 0000000000..2153cc24fa
+--- /dev/null
++++ b/core/modules/language/tests/language_events_test/config/schema/config_events_test.schema.yml
+@@ -0,0 +1,7 @@
++config_events_test.test:
++  type: config_object
++  label: 'Configuration events test'
++  mapping:
++    key:
++      type: string
++      label: 'Value'
+diff --git a/core/modules/language/tests/language_events_test/language_events_test.info.yml b/core/modules/language/tests/language_events_test/language_events_test.info.yml
+new file mode 100644
+index 0000000000..0bf0bd633e
+--- /dev/null
++++ b/core/modules/language/tests/language_events_test/language_events_test.info.yml
+@@ -0,0 +1,4 @@
++name: 'Language events test'
++type: module
++package: Testing
++version: VERSION
+diff --git a/core/modules/language/tests/language_events_test/language_events_test.services.yml b/core/modules/language/tests/language_events_test/language_events_test.services.yml
+new file mode 100644
+index 0000000000..5bba4650ee
+--- /dev/null
++++ b/core/modules/language/tests/language_events_test/language_events_test.services.yml
+@@ -0,0 +1,6 @@
++services:
++  language_events_test.event_subscriber:
++    class: Drupal\language_events_test\EventSubscriber
++    arguments: ['@state']
++    tags:
++      - { name: event_subscriber }
+diff --git a/core/modules/language/tests/language_events_test/src/EventSubscriber.php b/core/modules/language/tests/language_events_test/src/EventSubscriber.php
+new file mode 100644
+index 0000000000..e805b9fc62
+--- /dev/null
++++ b/core/modules/language/tests/language_events_test/src/EventSubscriber.php
+@@ -0,0 +1,56 @@
++<?php
++
++namespace Drupal\language_events_test;
++
++use Drupal\Core\State\StateInterface;
++use Drupal\language\Config\LanguageConfigOverrideEvents;
++use Drupal\language\Config\LanguageConfigOverrideCrudEvent;
++use Symfony\Component\EventDispatcher\EventSubscriberInterface;
++
++class EventSubscriber implements EventSubscriberInterface {
++
++  /**
++   * Constructs the Event Subscriber object.
++   *
++   * @param \Drupal\Core\State\StateInterface $state
++   *   The state key value store.
++   */
++  public function __construct(private StateInterface $state) {
++  }
++
++  /**
++   * Reacts to config event.
++   *
++   * @param \Drupal\language\Config\LanguageConfigOverrideCrudEvent $event
++   *   The language configuration event.
++   * @param string $event_name
++   *   The event name.
++   */
++  public function configEventRecorder(LanguageConfigOverrideCrudEvent $event, string $event_name): void {
++    $override = $event->getLanguageConfigOverride();
++    $event_info = [
++      'event_name' => $event_name,
++      'current_override_data' => $override->get(),
++      'original_override_data' => $override->getOriginal(),
++    ];
++
++    // Record all events that occur.
++    $all_events = $this->state->get('language_events_test.all_events', []);
++    $override_name = $override->getName();
++    if (!isset($all_events[$event_name][$override_name])) {
++      $all_events[$event_name][$override_name] = [];
++    }
++    $all_events[$event_name][$override_name][] = $event_info;
++    $this->state->set('language_events_test.all_events', $all_events);
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public static function getSubscribedEvents(): array {
++    $events[LanguageConfigOverrideEvents::SAVE_OVERRIDE][] = ['configEventRecorder'];
++    $events[LanguageConfigOverrideEvents::DELETE_OVERRIDE][] = ['configEventRecorder'];
++    return $events;
++  }
++
++}
+diff --git a/core/modules/language/tests/src/Functional/LanguageConfigOverrideImportTest.php b/core/modules/language/tests/src/Functional/LanguageConfigOverrideImportTest.php
+index 2600627b3a..5657cf7eb3 100644
+--- a/core/modules/language/tests/src/Functional/LanguageConfigOverrideImportTest.php
++++ b/core/modules/language/tests/src/Functional/LanguageConfigOverrideImportTest.php
+@@ -2,6 +2,7 @@
+ 
+ namespace Drupal\Tests\language\Functional;
+ 
++use Drupal\Core\Config\ConfigCollectionEvents;
+ use Drupal\language\Entity\ConfigurableLanguage;
+ use Drupal\Tests\BrowserTestBase;
+ 
+@@ -91,7 +92,12 @@ public function testConfigOverrideImportEvents() {
+     // Test that no config save event has been fired during the import because
+     // language configuration overrides do not fire events.
+     $event_recorder = \Drupal::state()->get('config_events_test.event', FALSE);
+-    $this->assertFalse($event_recorder);
++    $this->assertSame([
++      'event_name' => ConfigCollectionEvents::SAVE_IN_COLLECTION,
++      'current_config_data' => ['name' => 'FR default site name'],
++      'original_config_data' => [],
++      'raw_config_data' => ['name' => 'FR default site name'],
++    ], $event_recorder);
+ 
+     $this->drupalGet('fr');
+     $this->assertSession()->pageTextContains('FR default site name');
+diff --git a/core/modules/language/tests/src/Kernel/LanguageConfigOverrideInstallTest.php b/core/modules/language/tests/src/Kernel/LanguageConfigOverrideInstallTest.php
+index 1883e93133..20d83179ca 100644
+--- a/core/modules/language/tests/src/Kernel/LanguageConfigOverrideInstallTest.php
++++ b/core/modules/language/tests/src/Kernel/LanguageConfigOverrideInstallTest.php
+@@ -2,6 +2,8 @@
+ 
+ namespace Drupal\Tests\language\Kernel;
+ 
++use Drupal\Core\Config\ConfigCollectionEvents;
++use Drupal\language\Config\LanguageConfigOverrideEvents;
+ use Drupal\language\Entity\ConfigurableLanguage;
+ use Drupal\KernelTests\KernelTestBase;
+ 
+@@ -17,22 +19,71 @@ class LanguageConfigOverrideInstallTest extends KernelTestBase {
+    *
+    * @var array
+    */
+-  protected static $modules = ['language', 'config_events_test'];
++  protected static $modules = ['language', 'config_events_test', 'language_events_test'];
+ 
+   /**
+    * Tests the configuration events are not fired during install of overrides.
+    */
+   public function testLanguageConfigOverrideInstall() {
++    $this->installConfig(['language']);
+     ConfigurableLanguage::createFromLangcode('de')->save();
+     // Need to enable test module after creating the language otherwise saving
+     // the language will install the configuration.
+     $this->enableModules(['language_config_override_test']);
+     \Drupal::state()->set('config_events_test.event', FALSE);
++    \Drupal::state()->set('language_events_test.all_events', []);
+     $this->installConfig(['language_config_override_test']);
++
++    // Ensure the save-in-collection event is triggered when saving data in
++    // config collections during an install.
+     $event_recorder = \Drupal::state()->get('config_events_test.event', FALSE);
+-    $this->assertFalse($event_recorder);
++    $this->assertSame([
++      'event_name' => ConfigCollectionEvents::SAVE_IN_COLLECTION,
++      'current_config_data' => ['name' => 'Deutsch'],
++      'original_config_data' => [],
++      'raw_config_data' => ['name' => 'Deutsch'],
++    ], $event_recorder);
+     $config = \Drupal::service('language.config_factory_override')->getOverride('de', 'language_config_override_test.settings');
+     $this->assertEquals('Deutsch', $config->get('name'));
++
++    // Ensure the save override event is triggered when saving overrides during
++    // an install.
++    $event_recorder = \Drupal::state()->get('language_events_test.all_events', []);
++    $this->assertArrayHasKey(LanguageConfigOverrideEvents::SAVE_OVERRIDE, $event_recorder);
++    $this->assertArrayHasKey('language_config_override_test.settings', $event_recorder[LanguageConfigOverrideEvents::SAVE_OVERRIDE]);
++    $this->assertSame([
++      'event_name' => LanguageConfigOverrideEvents::SAVE_OVERRIDE,
++      'current_override_data' => ['name' => 'Deutsch'],
++      'original_override_data' => [],
++    ], $event_recorder['language.save_override']['language_config_override_test.settings'][0]);
++
++    // Test events during uninstall.
++    \Drupal::state()->set('config_events_test.all_events', []);
++    \Drupal::state()->set('language_events_test.all_events', []);
++    $this->container->get('module_installer')->uninstall(['language_config_override_test']);
++
++    // Ensure the delete-in-collection event is triggered when deleting data in
++    // config collections during an uninstall.
++    $event_recorder = \Drupal::state()->get('config_events_test.all_events', []);
++    $this->assertArrayHasKey(ConfigCollectionEvents::DELETE_IN_COLLECTION, $event_recorder);
++    $this->assertArrayHasKey('language_config_override_test.settings', $event_recorder[ConfigCollectionEvents::DELETE_IN_COLLECTION]);
++    $this->assertSame([
++      'event_name' => ConfigCollectionEvents::DELETE_IN_COLLECTION,
++      'current_config_data' => [],
++      'original_config_data' => ['name' => 'Deutsch'],
++      'raw_config_data' => [],
++    ], $event_recorder[ConfigCollectionEvents::DELETE_IN_COLLECTION]['language_config_override_test.settings'][0]);
++
++    // Ensure the delete override event is triggered when deleting overrides
++    // during an uninstall.
++    $event_recorder = \Drupal::state()->get('language_events_test.all_events', []);
++    $this->assertArrayHasKey(LanguageConfigOverrideEvents::DELETE_OVERRIDE, $event_recorder);
++    $this->assertArrayHasKey('language_config_override_test.settings', $event_recorder[LanguageConfigOverrideEvents::DELETE_OVERRIDE]);
++    $this->assertSame([
++      'event_name' => LanguageConfigOverrideEvents::DELETE_OVERRIDE,
++      'current_override_data' => [],
++      'original_override_data' => ['name' => 'Deutsch'],
++    ], $event_recorder['language.delete_override']['language_config_override_test.settings'][0]);
+   }
+ 
+ }
+diff --git a/core/modules/user/src/Entity/Role.php b/core/modules/user/src/Entity/Role.php
+index 18194f3390..68ddd501f5 100644
+--- a/core/modules/user/src/Entity/Role.php
++++ b/core/modules/user/src/Entity/Role.php
+@@ -2,8 +2,10 @@
+ 
+ namespace Drupal\user\Entity;
+ 
++use Drupal\Core\Config\Action\Attribute\ActionMethod;
+ use Drupal\Core\Config\Entity\ConfigEntityBase;
+ use Drupal\Core\Entity\EntityStorageInterface;
++use Drupal\Core\StringTranslation\TranslatableMarkup;
+ use Drupal\user\RoleInterface;
+ 
+ /**
+@@ -126,6 +128,7 @@ public function hasPermission($permission) {
+   /**
+    * {@inheritdoc}
+    */
++  #[ActionMethod(adminLabel: new TranslatableMarkup('Add permission to role'))]
+   public function grantPermission($permission) {
+     if ($this->isAdmin()) {
+       return $this;
+diff --git a/core/recipes/example/composer.json b/core/recipes/example/composer.json
+new file mode 100644
+index 0000000000..1d231ba7ee
+--- /dev/null
++++ b/core/recipes/example/composer.json
+@@ -0,0 +1,9 @@
++{
++  "name": "drupal_recipe/example",
++  "description": "An example Drupal recipe description",
++  "type": "drupal-recipe",
++  "require": {
++    "drupal/core": "^10.0.x-dev"
++  },
++  "license": "GPL-2.0-or-later"
++}
+diff --git a/core/recipes/example/recipe.yml b/core/recipes/example/recipe.yml
+new file mode 100644
+index 0000000000..2103651c07
+--- /dev/null
++++ b/core/recipes/example/recipe.yml
+@@ -0,0 +1,46 @@
++# The type key is similar to the package key in module.info.yml. It
++# can be used by the UI to group Drupal recipes. Additionally,
++# the type 'Site' means that the Drupal recipe will be listed in
++# the installer.
++type: 'Content type'
++
++install:
++  # An array of modules or themes to install, if they are not already.
++  # The system will detect if it is a theme or a module. During the
++  # install only simple configuration from the new modules is created.
++  # This allows the Drupal recipe control over the configuration.
++  - node
++  - text
++
++config:
++  # A Drupal recipe can have a config directory. All configuration
++  # is this directory will be imported after the modules have been
++  # installed.
++
++  # Additionally, the Drupal recipe can install configuration entities
++  # provided by the modules it configures. This allows them to not have
++  # to maintain or copy this configuration. Note the examples below are
++  # fictitious.
++  import:
++    node:
++      - node.type.article
++    # Import all configuration that is provided by the text module and any
++    # optional configuration that depends on the text module that is provided by
++    # modules already installed.
++    text: *
++
++  # Configuration actions may be defined. The structure here should be
++  # entity_type.ID.action. Below the user role entity type with an ID of
++  # editor is having the permissions added. The permissions key will be
++  # mapped to the \Drupal\user\Entity\Role::grantPermission() method.
++  actions:
++    user.role.editor:
++      ensure_exists:
++        label: 'Editor'
++      grantPermissions:
++        - 'delete any article content'
++        - 'edit any article content'
++
++content:
++# A Drupal recipe can have a content directory. All content in this
++# directory will be created after the configuration is installed.
+diff --git a/core/scripts/drupal b/core/scripts/drupal
+index 891d5b8117..0c9eb300cd 100644
+--- a/core/scripts/drupal
++++ b/core/scripts/drupal
+@@ -10,6 +10,7 @@ use Drupal\Core\Command\GenerateTheme;
+ use Drupal\Core\Command\QuickStartCommand;
+ use Drupal\Core\Command\InstallCommand;
+ use Drupal\Core\Command\ServerCommand;
++use Drupal\Core\Recipe\RecipeCommand;
+ use Symfony\Component\Console\Application;
+ 
+ if (PHP_SAPI !== 'cli') {
+@@ -24,5 +25,6 @@ $application->add(new QuickStartCommand());
+ $application->add(new InstallCommand($classloader));
+ $application->add(new ServerCommand($classloader));
+ $application->add(new GenerateTheme());
++$application->add(new RecipeCommand($classloader));
+ 
+ $application->run();
+diff --git a/core/tests/Drupal/FunctionalTests/Core/Recipe/RecipeCommandTest.php b/core/tests/Drupal/FunctionalTests/Core/Recipe/RecipeCommandTest.php
+new file mode 100644
+index 0000000000..1a3559910a
+--- /dev/null
++++ b/core/tests/Drupal/FunctionalTests/Core/Recipe/RecipeCommandTest.php
+@@ -0,0 +1,103 @@
++<?php
++
++namespace Drupal\FunctionalTests\Core\Recipe;
++
++use Drupal\Core\Config\Checkpoint\Checkpoint;
++use Drupal\node\Entity\NodeType;
++use Drupal\Tests\BrowserTestBase;
++use Symfony\Component\Process\PhpExecutableFinder;
++use Symfony\Component\Process\Process;
++
++/**
++ * @coversDefaultClass \Drupal\Core\Recipe\RecipeCommand
++ * @group Recipe
++ *
++ * BrowserTestBase is used for a proper Drupal install.
++ */
++class RecipeCommandTest extends BrowserTestBase {
++
++  /**
++   * {@inheritdoc}
++   */
++  protected $defaultTheme = 'stark';
++
++  public function testRecipeCommand(): void {
++    $this->assertFalse(\Drupal::moduleHandler()->moduleExists('node'), 'The node module is not installed');
++    $this->assertCheckpointsExist([]);
++
++    $process = $this->runRecipeCommand('core/tests/fixtures/recipes/install_node_with_config');
++    $this->assertSame(0, $process->getExitCode());
++    $this->assertSame('', $process->getErrorOutput());
++    $this->assertStringContainsString('Install node with config applied successfully', $process->getOutput());
++    $this->assertTrue(\Drupal::moduleHandler()->moduleExists('node'), 'The node module is installed');
++    $this->assertCheckpointsExist(["Backup before the 'Install node with config' recipe."]);
++
++    // Ensure recipes can be applied without affecting pre-existing checkpoints.
++    $process = $this->runRecipeCommand('core/tests/fixtures/recipes/install_two_modules');
++    $this->assertSame(0, $process->getExitCode());
++    $this->assertSame('', $process->getErrorOutput());
++    $this->assertStringContainsString('Install two modules applied successfully', $process->getOutput());
++    $this->assertTrue(\Drupal::moduleHandler()->moduleExists('node'), 'The node module is installed');
++    $this->assertCheckpointsExist([
++      "Backup before the 'Install node with config' recipe.",
++      "Backup before the 'Install two modules' recipe.",
++    ]);
++
++    // Ensure recipes that fail have an exception message.
++    NodeType::load('test')?->delete();
++    $process = $this->runRecipeCommand('core/tests/fixtures/recipes/unmet_config_dependencies');
++    $this->assertSame(1, $process->getExitCode());
++    $this->assertStringContainsString("The configuration 'node.type.test' has unmet dependencies", $process->getErrorOutput());
++    $this->assertCheckpointsExist([
++      "Backup before the 'Install node with config' recipe.",
++      "Backup before the 'Install two modules' recipe.",
++      "Backup before the 'Unmet config dependencies' recipe.",
++    ]);
++  }
++
++  /**
++   * Asserts that the current set of checkpoints matches the given labels.
++   *
++   * @param string[] $expected_labels
++   *   The labels of every checkpoint that is expected to exist currently, in
++   *   the expected order.
++   */
++  private function assertCheckpointsExist(array $expected_labels): void {
++    $checkpoints = \Drupal::service('config.checkpoints');
++    $labels = array_map(fn (Checkpoint $c) => $c->label, iterator_to_array($checkpoints));
++    $this->assertSame($expected_labels, array_values($labels));
++  }
++
++  /**
++   * Runs the `drupal recipe` command.
++   *
++   * @param string ...$arguments
++   *   Additional arguments to pass to the command.
++   *
++   * @return \Symfony\Component\Process\Process
++   *   The command process, after it has run.
++   */
++  private function runRecipeCommand(string ...$arguments): Process {
++    array_unshift($arguments, (new PhpExecutableFinder())->find(), 'core/scripts/drupal', 'recipe');
++
++    $process = (new Process($arguments))
++      ->setWorkingDirectory($this->getDrupalRoot())
++      ->setEnv([
++        'DRUPAL_DEV_SITE_PATH' => $this->siteDirectory,
++      ])
++      ->setTimeout(500);
++
++    $process->run();
++    // Applying a recipe:
++    // - creates new checkpoints, hence the "state" service in the test runner
++    //   is outdated
++    // - may install modules, which would cause the entire container in the test
++    //   runner to be outdated.
++    // Hence the entire environment must be rebuilt for assertions to target the
++    // actual post-recipe-application result.
++    // @see \Drupal\Core\Config\Checkpoint\LinearHistory::__construct()
++    $this->rebuildAll();
++    return $process;
++  }
++
++}
+diff --git a/core/tests/Drupal/KernelTests/Core/Config/Action/ConfigActionTest.php b/core/tests/Drupal/KernelTests/Core/Config/Action/ConfigActionTest.php
+new file mode 100644
+index 0000000000..3681457776
+--- /dev/null
++++ b/core/tests/Drupal/KernelTests/Core/Config/Action/ConfigActionTest.php
+@@ -0,0 +1,322 @@
++<?php
++
++namespace Drupal\KernelTests\Core\Config\Action;
++
++// cspell:ignore inflector
++use Drupal\Component\Plugin\Exception\PluginNotFoundException;
++use Drupal\Component\Uuid\Uuid;
++use Drupal\config_test\ConfigActionErrorEntity\DuplicatePluralizedMethodName;
++use Drupal\config_test\ConfigActionErrorEntity\DuplicatePluralizedOtherMethodName;
++use Drupal\Core\Config\Action\ConfigActionException;
++use Drupal\Core\Config\Action\DuplicateConfigActionIdException;
++use Drupal\Core\Config\Action\EntityMethodException;
++use Drupal\KernelTests\KernelTestBase;
++
++/**
++ * Tests the config action system.
++ *
++ * @group config
++ */
++class ConfigActionTest extends KernelTestBase {
++
++  /**
++   * {@inheritdoc}
++   */
++  protected static $modules = ['config_test'];
++
++  /**
++   * @see \Drupal\Core\Config\Action\Plugin\ConfigAction\EntityCreate
++   */
++  public function testEntityCreate(): void {
++    $this->assertCount(0, \Drupal::entityTypeManager()->getStorage('config_test')->loadMultiple(), 'There are no config_test entities');
++    /** @var \Drupal\Core\Config\Action\ConfigActionManager $manager */
++    $manager = $this->container->get('plugin.manager.config_action');
++    $manager->applyAction('entity_create:ensure_exists', 'config_test.dynamic.action_test', ['label' => 'Action test']);
++    /** @var \Drupal\config_test\Entity\ConfigTest[] $config_test_entities */
++    $config_test_entities = \Drupal::entityTypeManager()->getStorage('config_test')->loadMultiple();
++    $this->assertCount(1, \Drupal::entityTypeManager()->getStorage('config_test')->loadMultiple(), 'There is 1 config_test entity');
++    $this->assertSame('Action test', $config_test_entities['action_test']->label());
++    $this->assertTrue(Uuid::isValid((string) $config_test_entities['action_test']->uuid()), 'Config entity assigned a valid UUID');
++
++    // Calling ensure exists action again will not error.
++    $manager->applyAction('entity_create:ensure_exists', 'config_test.dynamic.action_test', ['label' => 'Action test']);
++
++    try {
++      $manager->applyAction('entity_create:create', 'config_test.dynamic.action_test', ['label' => 'Action test']);
++      $this->fail('Expected exception not thrown');
++    }
++    catch (ConfigActionException $e) {
++      $this->assertSame('Entity config_test.dynamic.action_test exists', $e->getMessage());
++    }
++  }
++
++  /**
++   * @see \Drupal\Core\Config\Action\Plugin\ConfigAction\EntityMethod
++   */
++  public function testEntityMethod(): void {
++    $this->installConfig('config_test');
++    $storage = \Drupal::entityTypeManager()->getStorage('config_test');
++
++    /** @var \Drupal\config_test\Entity\ConfigTest $config_test_entity */
++    $config_test_entity = $storage->load('dotted.default');
++    $this->assertSame('Default', $config_test_entity->getProtectedProperty());
++
++    /** @var \Drupal\Core\Config\Action\ConfigActionManager $manager */
++    $manager = $this->container->get('plugin.manager.config_action');
++    // Call a method action.
++    $manager->applyAction('entity_method:config_test.dynamic:setProtectedProperty', 'config_test.dynamic.dotted.default', 'Test value');
++    /** @var \Drupal\config_test\Entity\ConfigTest $config_test_entity */
++    $config_test_entity = $storage->load('dotted.default');
++    $this->assertSame('Test value', $config_test_entity->getProtectedProperty());
++
++    $manager->applyAction('entity_method:config_test.dynamic:setProtectedProperty', 'config_test.dynamic.dotted.default', 'Test value 2');
++    /** @var \Drupal\config_test\Entity\ConfigTest $config_test_entity */
++    $config_test_entity = $storage->load('dotted.default');
++    $this->assertSame('Test value 2', $config_test_entity->getProtectedProperty());
++
++    $manager->applyAction('entity_method:config_test.dynamic:concatProtectedProperty', 'config_test.dynamic.dotted.default', ['Test value ', '3']);
++    /** @var \Drupal\config_test\Entity\ConfigTest $config_test_entity */
++    $config_test_entity = $storage->load('dotted.default');
++    $this->assertSame('Test value 3', $config_test_entity->getProtectedProperty());
++
++    $manager->applyAction('entity_method:config_test.dynamic:concatProtectedPropertyOptional', 'config_test.dynamic.dotted.default', ['Test value ', '4']);
++    /** @var \Drupal\config_test\Entity\ConfigTest $config_test_entity */
++    $config_test_entity = $storage->load('dotted.default');
++    $this->assertSame('Test value 4', $config_test_entity->getProtectedProperty());
++
++    // Test calling an action that has 2 arguments but one is optional with an
++    // array value.
++    $manager->applyAction('entity_method:config_test.dynamic:concatProtectedPropertyOptional', 'config_test.dynamic.dotted.default', ['Test value 5']);
++    /** @var \Drupal\config_test\Entity\ConfigTest $config_test_entity */
++    $config_test_entity = $storage->load('dotted.default');
++    $this->assertSame('Test value 5', $config_test_entity->getProtectedProperty());
++
++    // Test calling an action that has 2 arguments but one is optional with a
++    // non array value.
++    $manager->applyAction('entity_method:config_test.dynamic:concatProtectedPropertyOptional', 'config_test.dynamic.dotted.default', 'Test value 6');
++    /** @var \Drupal\config_test\Entity\ConfigTest $config_test_entity */
++    $config_test_entity = $storage->load('dotted.default');
++    $this->assertSame('Test value 6', $config_test_entity->getProtectedProperty());
++
++    // Test calling an action that expects no arguments.
++    $manager->applyAction('entity_method:config_test.dynamic:defaultProtectedProperty', 'config_test.dynamic.dotted.default', []);
++    /** @var \Drupal\config_test\Entity\ConfigTest $config_test_entity */
++    $config_test_entity = $storage->load('dotted.default');
++    $this->assertSame('Set by method', $config_test_entity->getProtectedProperty());
++
++    $manager->applyAction('entity_method:config_test.dynamic:addToArray', 'config_test.dynamic.dotted.default', 'foo');
++    $manager->applyAction('entity_method:config_test.dynamic:addToArray', 'config_test.dynamic.dotted.default', 'bar');
++    /** @var \Drupal\config_test\Entity\ConfigTest $config_test_entity */
++    $config_test_entity = $storage->load('dotted.default');
++    $this->assertSame(['foo', 'bar'], $config_test_entity->getArrayProperty());
++
++    $manager->applyAction('entity_method:config_test.dynamic:addToArray', 'config_test.dynamic.dotted.default', ['a', 'b', 'c']);
++    /** @var \Drupal\config_test\Entity\ConfigTest $config_test_entity */
++    $config_test_entity = $storage->load('dotted.default');
++    $this->assertSame(['foo', 'bar', ['a', 'b', 'c']], $config_test_entity->getArrayProperty());
++
++    $manager->applyAction('entity_method:config_test.dynamic:setArray', 'config_test.dynamic.dotted.default', ['a', 'b', 'c']);
++    /** @var \Drupal\config_test\Entity\ConfigTest $config_test_entity */
++    $config_test_entity = $storage->load('dotted.default');
++    $this->assertSame(['a', 'b', 'c'], $config_test_entity->getArrayProperty());
++
++    $manager->applyAction('entity_method:config_test.dynamic:setArray', 'config_test.dynamic.dotted.default', [['a', 'b', 'c'], ['a']]);
++    /** @var \Drupal\config_test\Entity\ConfigTest $config_test_entity */
++    $config_test_entity = $storage->load('dotted.default');
++    $this->assertSame([['a', 'b', 'c'], ['a']], $config_test_entity->getArrayProperty());
++
++    $config_test_entity->delete();
++    try {
++      $manager->applyAction('entity_method:config_test.dynamic:setProtectedProperty', 'config_test.dynamic.dotted.default', 'Test value');
++      $this->fail('Expected exception not thrown');
++    }
++    catch (ConfigActionException $e) {
++      $this->assertSame('Entity config_test.dynamic.dotted.default does not exist', $e->getMessage());
++    }
++
++    // Test custom and default admin labels.
++    $this->assertSame('Test configuration append', (string) $manager->getDefinition('entity_method:config_test.dynamic:append')['admin_label']);
++    $this->assertSame('Set default name', (string) $manager->getDefinition('entity_method:config_test.dynamic:defaultProtectedProperty')['admin_label']);
++  }
++
++  /**
++   * @see \Drupal\Core\Config\Action\Plugin\ConfigAction\EntityMethod
++   */
++  public function testPluralizedEntityMethod(): void {
++    $this->installConfig('config_test');
++    $storage = \Drupal::entityTypeManager()->getStorage('config_test');
++
++    /** @var \Drupal\Core\Config\Action\ConfigActionManager $manager */
++    $manager = $this->container->get('plugin.manager.config_action');
++    // Call a pluralized method action.
++    $manager->applyAction('entity_method:config_test.dynamic:addToArrayMultipleTimes', 'config_test.dynamic.dotted.default', ['a', 'b', 'c', 'd']);
++    /** @var \Drupal\config_test\Entity\ConfigTest $config_test_entity */
++    $config_test_entity = $storage->load('dotted.default');
++    $this->assertSame(['a', 'b', 'c', 'd'], $config_test_entity->getArrayProperty());
++
++    $manager->applyAction('entity_method:config_test.dynamic:addToArrayMultipleTimes', 'config_test.dynamic.dotted.default', [['foo'], 'bar']);
++    /** @var \Drupal\config_test\Entity\ConfigTest $config_test_entity */
++    $config_test_entity = $storage->load('dotted.default');
++    $this->assertSame(['a', 'b', 'c', 'd', ['foo'], 'bar'], $config_test_entity->getArrayProperty());
++
++    $config_test_entity->setProtectedProperty('')->save();
++    $manager->applyAction('entity_method:config_test.dynamic:appends', 'config_test.dynamic.dotted.default', ['1', '2', '3']);
++    /** @var \Drupal\config_test\Entity\ConfigTest $config_test_entity */
++    $config_test_entity = $storage->load('dotted.default');
++    $this->assertSame('123', $config_test_entity->getProtectedProperty());
++
++    // Test that the inflector converts to a good plural form.
++    $config_test_entity->setProtectedProperty('')->save();
++    $manager->applyAction('entity_method:config_test.dynamic:concatProtectedProperties', 'config_test.dynamic.dotted.default', [['1', '2'], ['3', '4']]);
++    /** @var \Drupal\config_test\Entity\ConfigTest $config_test_entity */
++    $config_test_entity = $storage->load('dotted.default');
++    $this->assertSame('34', $config_test_entity->getProtectedProperty());
++
++    $this->assertTrue($manager->hasDefinition('entity_method:config_test.dynamic:setProtectedProperty'), 'The setProtectedProperty action exists');
++    // cspell:ignore Propertys
++    $this->assertFalse($manager->hasDefinition('entity_method:config_test.dynamic:setProtectedPropertys'), 'There is no automatically pluralized version of the setProtectedProperty action');
++
++    // Admin label for pluralized form.
++    $this->assertSame('Test configuration append (multiple calls)', (string) $manager->getDefinition('entity_method:config_test.dynamic:appends')['admin_label']);
++  }
++
++  /**
++   * @see \Drupal\Core\Config\Action\Plugin\ConfigAction\EntityMethod
++   */
++  public function testPluralizedEntityMethodException(): void {
++    $this->installConfig('config_test');
++    /** @var \Drupal\Core\Config\Action\ConfigActionManager $manager */
++    $manager = $this->container->get('plugin.manager.config_action');
++    $this->expectException(EntityMethodException::class);
++    $this->expectExceptionMessage('The pluralized entity method config action \'entity_method:config_test.dynamic:addToArrayMultipleTimes\' requires an array value in order to call Drupal\config_test\Entity\ConfigTest::addToArray() multiple times');
++    $manager->applyAction('entity_method:config_test.dynamic:addToArrayMultipleTimes', 'config_test.dynamic.dotted.default', 'Test value');
++  }
++
++  /**
++   * @see \Drupal\Core\Config\Action\Plugin\ConfigAction\Deriver\EntityMethodDeriver
++   */
++  public function testDuplicatePluralizedMethodNameException(): void {
++    \Drupal::state()->set('config_test.class_override', DuplicatePluralizedMethodName::class);
++    \Drupal::entityTypeManager()->clearCachedDefinitions();
++    $this->installConfig('config_test');
++    /** @var \Drupal\Core\Config\Action\ConfigActionManager $manager */
++    $manager = $this->container->get('plugin.manager.config_action');
++    $this->expectException(EntityMethodException::class);
++    $this->expectExceptionMessage('Duplicate action can not be created for ID \'config_test.dynamic:testMethod\' for Drupal\config_test\ConfigActionErrorEntity\DuplicatePluralizedMethodName::testMethod(). The existing action is for the ::testMethod() method');
++    $manager->getDefinitions();
++  }
++
++  /**
++   * @see \Drupal\Core\Config\Action\Plugin\ConfigAction\Deriver\EntityMethodDeriver
++   */
++  public function testDuplicatePluralizedOtherMethodNameException(): void {
++    \Drupal::state()->set('config_test.class_override', DuplicatePluralizedOtherMethodName::class);
++    \Drupal::entityTypeManager()->clearCachedDefinitions();
++    $this->installConfig('config_test');
++    /** @var \Drupal\Core\Config\Action\ConfigActionManager $manager */
++    $manager = $this->container->get('plugin.manager.config_action');
++    $this->expectException(EntityMethodException::class);
++    $this->expectExceptionMessage('Duplicate action can not be created for ID \'config_test.dynamic:testMethod2\' for Drupal\config_test\ConfigActionErrorEntity\DuplicatePluralizedOtherMethodName::testMethod2(). The existing action is for the ::testMethod() method');
++    $manager->getDefinitions();
++  }
++
++  /**
++   * @see \Drupal\Core\Config\Action\Plugin\ConfigAction\EntityMethod
++   */
++  public function testEntityMethodException(): void {
++    $this->installConfig('config_test');
++    /** @var \Drupal\Core\Config\Action\ConfigActionManager $manager */
++    $manager = $this->container->get('plugin.manager.config_action');
++    $this->expectException(EntityMethodException::class);
++    $this->expectExceptionMessage('Entity method config action \'entity_method:config_test.dynamic:concatProtectedProperty\' requires an array value. The number of parameters or required parameters for Drupal\config_test\Entity\ConfigTest::concatProtectedProperty() is not 1');
++    $manager->applyAction('entity_method:config_test.dynamic:concatProtectedProperty', 'config_test.dynamic.dotted.default', 'Test value');
++  }
++
++  /**
++   * @see \Drupal\Core\Config\Action\Plugin\ConfigAction\SimpleConfigUpdate
++   */
++  public function testSimpleConfigUpdate(): void {
++    $this->installConfig('config_test');
++    $this->assertSame('bar', $this->config('config_test.system')->get('foo'));
++
++    /** @var \Drupal\Core\Config\Action\ConfigActionManager $manager */
++    $manager = $this->container->get('plugin.manager.config_action');
++    // Call the simple config update action.
++    $manager->applyAction('simple_config_update', 'config_test.system', ['foo' => 'Yay!']);
++    $this->assertSame('Yay!', $this->config('config_test.system')->get('foo'));
++
++    try {
++      $manager->applyAction('simple_config_update', 'config_test.system', 'Test');
++      $this->fail('Expected exception not thrown');
++    }
++    catch (ConfigActionException $e) {
++      $this->assertSame('Config config_test.system can not be updated because $value is not an array', $e->getMessage());
++    }
++
++    $this->config('config_test.system')->delete();
++    try {
++      $manager->applyAction('simple_config_update', 'config_test.system', ['foo' => 'Yay!']);
++      $this->fail('Expected exception not thrown');
++    }
++    catch (ConfigActionException $e) {
++      $this->assertSame('Config config_test.system does not exist so can not be updated', $e->getMessage());
++    }
++  }
++
++  /**
++   * @see \Drupal\Core\Config\Action\ConfigActionManager::getShorthandActionIdsForEntityType()
++   */
++  public function testShorthandActionIds(): void {
++    $storage = \Drupal::entityTypeManager()->getStorage('config_test');
++    $this->assertCount(0, $storage->loadMultiple(), 'There are no config_test entities');
++    /** @var \Drupal\Core\Config\Action\ConfigActionManager $manager */
++    $manager = $this->container->get('plugin.manager.config_action');
++    $manager->applyAction('ensure_exists', 'config_test.dynamic.action_test', ['label' => 'Action test', 'protected_property' => '']);
++    /** @var \Drupal\config_test\Entity\ConfigTest[] $config_test_entities */
++    $config_test_entities = $storage->loadMultiple();
++    $this->assertCount(1, $config_test_entities, 'There is 1 config_test entity');
++    $this->assertSame('Action test', $config_test_entities['action_test']->label());
++
++    $this->assertSame('', $config_test_entities['action_test']->getProtectedProperty());
++
++    /** @var \Drupal\Core\Config\Action\ConfigActionManager $manager */
++    $manager = $this->container->get('plugin.manager.config_action');
++    // Call a method action.
++    $manager->applyAction('setProtectedProperty', 'config_test.dynamic.action_test', 'Test value');
++    /** @var \Drupal\config_test\Entity\ConfigTest $config_test_entity */
++    $config_test_entity = $storage->load('action_test');
++    $this->assertSame('Test value', $config_test_entity->getProtectedProperty());
++  }
++
++  /**
++   * @see \Drupal\Core\Config\Action\ConfigActionManager::getShorthandActionIdsForEntityType()
++   */
++  public function testDuplicateShorthandActionIds(): void {
++    $this->enableModules(['config_action_duplicate_test']);
++    /** @var \Drupal\Core\Config\Action\ConfigActionManager $manager */
++    $manager = $this->container->get('plugin.manager.config_action');
++    $this->expectException(DuplicateConfigActionIdException::class);
++    $this->expectExceptionMessage("The plugins 'entity_method:config_test.dynamic:setProtectedProperty' and 'config_action_duplicate_test:config_test.dynamic:setProtectedProperty' both resolve to the same shorthand action ID for the 'config_test' entity type");
++    $manager->applyAction('ensure_exists', 'config_test.dynamic.action_test', ['label' => 'Action test', 'protected_property' => '']);
++  }
++
++  /**
++   * @see \Drupal\Core\Config\Action\ConfigActionManager::getShorthandActionIdsForEntityType()
++   */
++  public function testParentAttributes(): void {
++    $definitions = $this->container->get('plugin.manager.config_action')->getDefinitions();
++    // The \Drupal\config_test\Entity\ConfigQueryTest::concatProtectedProperty()
++    // does not have an attribute but the parent does so this is discovered.
++    $this->assertArrayHasKey('entity_method:config_test.query:concatProtectedProperty', $definitions);
++  }
++
++  /**
++   * @see \Drupal\Core\Config\Action\ConfigActionManager
++   */
++  public function testMissingAction(): void {
++    $this->expectException(PluginNotFoundException::class);
++    $this->expectExceptionMessageMatches('/^The "does_not_exist" plugin does not exist/');
++    $this->container->get('plugin.manager.config_action')->applyAction('does_not_exist', 'config_test.system', ['foo' => 'Yay!']);
++  }
++
++}
+diff --git a/core/tests/Drupal/KernelTests/Core/Config/ConfigImporterTest.php b/core/tests/Drupal/KernelTests/Core/Config/ConfigImporterTest.php
+index 9f4b9aa31b..bf17339b8b 100644
+--- a/core/tests/Drupal/KernelTests/Core/Config/ConfigImporterTest.php
++++ b/core/tests/Drupal/KernelTests/Core/Config/ConfigImporterTest.php
+@@ -4,6 +4,7 @@
+ 
+ use Drupal\Component\Utility\Html;
+ use Drupal\Component\Render\FormattableMarkup;
++use Drupal\Core\Config\ConfigCollectionEvents;
+ use Drupal\Core\Config\ConfigEvents;
+ use Drupal\Core\Config\ConfigImporter;
+ use Drupal\Core\Config\ConfigImporterException;
+@@ -930,6 +931,44 @@ public function testConfigEvents(): void {
+     $this->assertSame(['key' => 'bar'], $event['original_config_data']);
+   }
+ 
++  /**
++   * Tests events and collections during a config import.
++   */
++  public function testEventsAndCollectionsImport(): void {
++    $collections = [
++      'another_collection',
++      'collection.test1',
++      'collection.test2',
++    ];
++    // Set the event listener to return three possible collections.
++    // @see \Drupal\config_collection_install_test\EventSubscriber
++    \Drupal::state()->set('config_collection_install_test.collection_names', $collections);
++    $this->enableModules(['config_collection_install_test']);
++    $this->installConfig(['config_collection_install_test']);
++
++    // Export the configuration and uninstall the module to test installing it
++    // via configuration import.
++    $this->copyConfig($this->container->get('config.storage'), $this->container->get('config.storage.sync'));
++    $this->container->get('module_installer')->uninstall(['config_collection_install_test']);
++    $this->assertEmpty($this->container->get('config.storage')->getAllCollectionNames());
++
++    \Drupal::state()->set('config_events_test.all_events', []);
++    $this->configImporter()->import();
++    $this->assertSame($collections, $this->container->get('config.storage')->getAllCollectionNames());
++
++    $all_events = \Drupal::state()->get('config_events_test.all_events');
++    $this->assertArrayHasKey('core.extension', $all_events[ConfigEvents::SAVE]);
++    // Ensure that config in collections does not have the regular configuration
++    // event triggered.
++    $this->assertArrayNotHasKey('config_collection_install_test.test', $all_events[ConfigEvents::SAVE]);
++    $this->assertCount(3, $all_events[ConfigCollectionEvents::SAVE_IN_COLLECTION]['config_collection_install_test.test']);
++    $event_collections = [];
++    foreach ($all_events[ConfigCollectionEvents::SAVE_IN_COLLECTION]['config_collection_install_test.test'] as $event) {
++      $event_collections[] = $event['current_config_data']['collection'];
++    }
++    $this->assertSame($collections, $event_collections);
++  }
++
+   /**
+    * Helper method to test custom config installer steps.
+    *
+diff --git a/core/tests/Drupal/KernelTests/Core/Config/ConfigInstallTest.php b/core/tests/Drupal/KernelTests/Core/Config/ConfigInstallTest.php
+index 604ab1df36..4655ae374e 100644
+--- a/core/tests/Drupal/KernelTests/Core/Config/ConfigInstallTest.php
++++ b/core/tests/Drupal/KernelTests/Core/Config/ConfigInstallTest.php
+@@ -2,6 +2,7 @@
+ 
+ namespace Drupal\KernelTests\Core\Config;
+ 
++use Drupal\Core\Config\ConfigCollectionEvents;
+ use Drupal\Core\Config\InstallStorage;
+ use Drupal\Core\Config\PreExistingConfigException;
+ use Drupal\Core\Config\UnmetDependenciesException;
+@@ -18,7 +19,7 @@ class ConfigInstallTest extends KernelTestBase {
+   /**
+    * {@inheritdoc}
+    */
+-  protected static $modules = ['system'];
++  protected static $modules = ['system', 'config_events_test'];
+ 
+   /**
+    * {@inheritdoc}
+@@ -146,10 +147,25 @@ public function testCollectionInstallationCollections() {
+ 
+     // Test that the config manager uninstalls configuration from collections
+     // as expected.
+-    \Drupal::service('config.manager')->uninstall('module', 'config_collection_install_test');
++    \Drupal::state()->set('config_events_test.all_events', []);
++    $this->container->get('config.manager')->uninstall('module', 'config_collection_install_test');
++    $all_events = \Drupal::state()->get('config_events_test.all_events');
++    $this->assertArrayHasKey(ConfigCollectionEvents::DELETE_IN_COLLECTION, $all_events);
++    // The delete-in-collection event has been triggered 3 times.
++    $this->assertCount(3, $all_events[ConfigCollectionEvents::DELETE_IN_COLLECTION]['config_collection_install_test.test']);
++    $event_collections = [];
++    foreach ($all_events[ConfigCollectionEvents::DELETE_IN_COLLECTION]['config_collection_install_test.test'] as $event) {
++      $event_collections[] = $event['original_config_data']['collection'];
++    }
++    $this->assertSame(['another_collection', 'collection.test1', 'collection.test2'], $event_collections);
+     $this->assertEquals(['entity'], $active_storage->getAllCollectionNames());
+-    \Drupal::service('config.manager')->uninstall('module', 'config_test');
++
++    \Drupal::state()->set('config_events_test.all_events', []);
++    $this->container->get('config.manager')->uninstall('module', 'config_test');
+     $this->assertEquals([], $active_storage->getAllCollectionNames());
++    $all_events = \Drupal::state()->get('config_events_test.all_events');
++    $this->assertArrayHasKey(ConfigCollectionEvents::DELETE_IN_COLLECTION, $all_events);
++    $this->assertCount(1, $all_events[ConfigCollectionEvents::DELETE_IN_COLLECTION]['config_test.dynamic.dotted.default']);
+   }
+ 
+   /**
+diff --git a/core/tests/Drupal/KernelTests/Core/Config/Storage/Checkpoint/CheckpointStorageTest.php b/core/tests/Drupal/KernelTests/Core/Config/Storage/Checkpoint/CheckpointStorageTest.php
+new file mode 100644
+index 0000000000..9032d234bc
+--- /dev/null
++++ b/core/tests/Drupal/KernelTests/Core/Config/Storage/Checkpoint/CheckpointStorageTest.php
+@@ -0,0 +1,310 @@
++<?php
++
++declare(strict_types=1);
++
++namespace Drupal\KernelTests\Core\Config\Storage\Checkpoint;
++
++use Drupal\Core\Config\Checkpoint\CheckpointStorageInterface;
++use Drupal\Core\Config\ConfigImporter;
++use Drupal\Core\Config\StorageComparer;
++use Drupal\KernelTests\KernelTestBase;
++
++/**
++ * Tests CheckpointStorage operations.
++ *
++ * @group config
++ */
++class CheckpointStorageTest extends KernelTestBase {
++
++  /**
++   * {@inheritdoc}
++   */
++  protected static $modules = ['system', 'config_test'];
++
++  /**
++   * {@inheritdoc}
++   */
++  protected function setUp(): void {
++    parent::setUp();
++    $this->installConfig(['system', 'config_test']);
++  }
++
++  public function testConfigSaveAndRead(): void {
++    $checkpoint_storage = $this->container->get('config.storage.checkpoint');
++
++    $this->config('system.site')->set('name', 'Test1')->save();
++    $check1 = $checkpoint_storage->checkpoint('A');
++    $this->config('system.site')->set('name', 'Test2')->save();
++    $check2 = $checkpoint_storage->checkpoint('B');
++    $this->config('system.site')->set('name', 'Test3')->save();
++
++    $this->assertSame('Test3', $this->config('system.site')->get('name'));
++    $this->assertSame('Test1', $checkpoint_storage->read('system.site')['name']);
++
++    // The config listings should be exactly the same.
++    $this->assertSame($checkpoint_storage->listAll(), $this->container->get('config.storage')->listAll());
++
++    $checkpoint_storage->setCheckpointToReadFrom($check2);
++    $this->assertSame('Test2', $checkpoint_storage->read('system.site')['name']);
++    $this->assertSame($checkpoint_storage->listAll(), $this->container->get('config.storage')->listAll());
++
++    $checkpoint_storage->setCheckpointToReadFrom($check1);
++    $this->assertSame('Test1', $checkpoint_storage->read('system.site')['name']);
++    $this->assertSame($checkpoint_storage->listAll(), $this->container->get('config.storage')->listAll());
++  }
++
++  public function testConfigDelete(): void {
++    $checkpoint_storage = $this->container->get('config.storage.checkpoint');
++
++    $check1 = $checkpoint_storage->checkpoint('A');
++    $this->config('config_test.system')->delete();
++
++    $this->assertFalse($this->container->get('config.storage')->exists('config_test.system'));
++    $this->assertTrue($checkpoint_storage->exists('config_test.system'));
++    $this->assertSame('bar', $checkpoint_storage->read('config_test.system')['foo']);
++
++    $this->assertContains('config_test.system', $checkpoint_storage->listAll());
++    $this->assertContains('config_test.system', $checkpoint_storage->listAll('config_test.'));
++    $this->assertNotContains('config_test.system', $checkpoint_storage->listAll('system.'));
++    // Should not be part of the active storage anymore.
++    $this->assertNotContains('config_test.system', $this->container->get('config.storage')->listAll());
++
++    $check2 = $checkpoint_storage->checkpoint('B');
++
++    $this->config('config_test.system')->set('foo', 'foobar')->save();
++    $this->assertTrue($this->container->get('config.storage')->exists('config_test.system'));
++    $this->assertTrue($checkpoint_storage->exists('config_test.system'));
++    $this->assertSame('bar', $checkpoint_storage->read('config_test.system')['foo']);
++
++    $checkpoint_storage->setCheckpointToReadFrom($check2);
++    $this->assertFalse($checkpoint_storage->exists('config_test.system'));
++    $this->assertFalse($checkpoint_storage->read('config_test.system'));
++    $this->assertNotContains('config_test.system', $checkpoint_storage->listAll());
++
++    $checkpoint_storage->setCheckpointToReadFrom($check1);
++    $this->assertTrue($checkpoint_storage->exists('config_test.system'));
++    $this->assertSame('bar', $checkpoint_storage->read('config_test.system')['foo']);
++    $this->assertContains('config_test.system', $checkpoint_storage->listAll());
++  }
++
++  public function testConfigCreate(): void {
++    $checkpoint_storage = $this->container->get('config.storage.checkpoint');
++
++    $this->config('config_test.system')->delete();
++    $check1 = $checkpoint_storage->checkpoint('A');
++    $this->config('config_test.system')->set('foo', 'foobar')->save();
++
++    $this->assertTrue($this->container->get('config.storage')->exists('config_test.system'));
++    $this->assertFalse($checkpoint_storage->exists('config_test.system'));
++    $this->assertFalse($checkpoint_storage->read('config_test.system'));
++
++    $this->assertNotContains('config_test.system', $checkpoint_storage->listAll());
++    $this->assertNotContains('config_test.system', $checkpoint_storage->listAll('config_test.'));
++    $this->assertContains('system.site', $checkpoint_storage->listAll('system.'));
++    $this->assertContains('config_test.system', $this->container->get('config.storage')->listAll());
++
++    $check2 = $checkpoint_storage->checkpoint('B');
++    $this->config('config_test.system')->delete();
++
++    $this->assertFalse($this->container->get('config.storage')->exists('config_test.system'));
++    $this->assertFalse($checkpoint_storage->exists('config_test.system'));
++    $this->assertFalse($checkpoint_storage->read('config_test.system'));
++
++    $this->config('config_test.system')->set('foo', 'foobar')->save();
++    $this->assertTrue($this->container->get('config.storage')->exists('config_test.system'));
++    $this->assertFalse($checkpoint_storage->exists('config_test.system'));
++    $this->assertFalse($checkpoint_storage->read('config_test.system'));
++
++    $checkpoint_storage->setCheckpointToReadFrom($check2);
++    $this->assertTrue($checkpoint_storage->exists('config_test.system'));
++    $this->assertSame('foobar', $checkpoint_storage->read('config_test.system')['foo']);
++    $this->assertContains('config_test.system', $checkpoint_storage->listAll());
++
++    $checkpoint_storage->setCheckpointToReadFrom($check1);
++    $this->assertFalse($checkpoint_storage->exists('config_test.system'));
++    $this->assertFalse($checkpoint_storage->read('config_test.system'));
++    $this->assertNotContains('config_test.system', $checkpoint_storage->listAll());
++  }
++
++  public function testConfigRename(): void {
++    $checkpoint_storage = $this->container->get('config.storage.checkpoint');
++    $check1 = $checkpoint_storage->checkpoint('A');
++    $this->container->get('config.factory')->rename('config_test.dynamic.dotted.default', 'config_test.dynamic.renamed');
++    $this->config('config_test.dynamic.renamed')->set('id', 'renamed')->save();
++
++    $this->assertFalse($checkpoint_storage->exists('config_test.dynamic.renamed'));
++    $this->assertTrue($checkpoint_storage->exists('config_test.dynamic.dotted.default'));
++    $this->assertSame('dotted.default', $checkpoint_storage->read('config_test.dynamic.dotted.default')['id']);
++    $this->assertSame($checkpoint_storage->read('config_test.dynamic.dotted.default')['uuid'], $this->config('config_test.dynamic.renamed')->get('uuid'));
++
++    $check2 = $checkpoint_storage->checkpoint('B');
++    /** @var \Drupal\Core\Config\Entity\ConfigEntityStorage $storage */
++    $storage = $this->container->get('entity_type.manager')->getStorage('config_test');
++    // Entity1 will be deleted by the test.
++    $entity1 = $storage->create(
++      [
++        'id' => 'dotted.default',
++        'label' => 'Another one',
++      ]
++    );
++    $entity1->save();
++
++    $check3 = $checkpoint_storage->checkpoint('C');
++
++    $checkpoint_storage->setCheckpointToReadFrom($check2);
++    $this->assertFalse($checkpoint_storage->exists('config_test.dynamic.dotted.default'));
++
++    $checkpoint_storage->setCheckpointToReadFrom($check3);
++    $this->assertTrue($checkpoint_storage->exists('config_test.dynamic.dotted.default'));
++    $this->assertNotEquals($checkpoint_storage->read('config_test.dynamic.dotted.default')['uuid'], $this->config('config_test.dynamic.renamed')->get('uuid'));
++    $this->assertSame('Another one', $checkpoint_storage->read('config_test.dynamic.dotted.default')['label']);
++
++    $checkpoint_storage->setCheckpointToReadFrom($check1);
++    $this->assertSame('Default', $checkpoint_storage->read('config_test.dynamic.dotted.default')['label']);
++  }
++
++  public function testRevert(): void {
++    $checkpoint_storage = $this->container->get('config.storage.checkpoint');
++    $check1 = $checkpoint_storage->checkpoint('A');
++    $this->assertTrue($this->container->get('module_installer')->uninstall(['config_test']));
++    $checkpoint_storage = $this->container->get('config.storage.checkpoint');
++    $check2 = $checkpoint_storage->checkpoint('B');
++
++    $importer = $this->getConfigImporter($checkpoint_storage);
++    $config_changelist = $importer->getStorageComparer()->createChangelist()->getChangelist();
++    $this->assertContains('config_test.dynamic.dotted.default', $config_changelist['create']);
++    $this->assertSame(['core.extension'], $config_changelist['update']);
++    $this->assertSame([], $config_changelist['delete']);
++    $this->assertSame([], $config_changelist['rename']);
++
++    $importer->import();
++    $this->assertSame([], $importer->getErrors());
++
++    $this->assertTrue($this->container->get('module_handler')->moduleExists('config_test'));
++
++    $checkpoint_storage = $this->container->get('config.storage.checkpoint');
++    $checkpoint_storage->setCheckpointToReadFrom($check2);
++
++    $importer = $this->getConfigImporter($checkpoint_storage);
++    $config_changelist = $importer->getStorageComparer()->createChangelist()->getChangelist();
++    $this->assertContains('config_test.dynamic.dotted.default', $config_changelist['delete']);
++    $this->assertSame(['core.extension'], $config_changelist['update']);
++    $this->assertSame([], $config_changelist['create']);
++    $this->assertSame([], $config_changelist['rename']);
++    $importer->import();
++    $this->assertFalse($this->container->get('module_handler')->moduleExists('config_test'));
++
++    $checkpoint_storage->setCheckpointToReadFrom($check1);
++    $importer = $this->getConfigImporter($checkpoint_storage);
++    $importer->getStorageComparer()->createChangelist();
++    $importer->import();
++    $this->assertTrue($this->container->get('module_handler')->moduleExists('config_test'));
++  }
++
++  public function testRevertWithCollections(): void {
++    $collections = [
++      'another_collection',
++      'collection.test1',
++      'collection.test2',
++    ];
++    // Set the event listener to return three possible collections.
++    // @see \Drupal\config_collection_install_test\EventSubscriber
++    \Drupal::state()->set('config_collection_install_test.collection_names', $collections);
++
++    $checkpoint_storage = $this->container->get('config.storage.checkpoint');
++    $checkpoint_storage->checkpoint('A');
++
++    // Install the test module.
++    $this->assertTrue($this->container->get('module_installer')->install(['config_collection_install_test']));
++    $checkpoint_storage = $this->container->get('config.storage.checkpoint');
++
++    /** @var \Drupal\Core\Config\StorageInterface $active_storage */
++    $active_storage = \Drupal::service('config.storage');
++    $this->assertEquals($collections, $active_storage->getAllCollectionNames());
++    foreach ($collections as $collection) {
++      $collection_storage = $active_storage->createCollection($collection);
++      $data = $collection_storage->read('config_collection_install_test.test');
++      $this->assertEquals($collection, $data['collection']);
++    }
++
++    $check2 = $checkpoint_storage->checkpoint('B');
++
++    $importer = $this->getConfigImporter($checkpoint_storage);
++    $storage_comparer = $importer->getStorageComparer();
++    $config_changelist = $storage_comparer->createChangelist()->getChangelist();
++    $this->assertSame([], $config_changelist['create']);
++    $this->assertSame(['core.extension'], $config_changelist['update']);
++    $this->assertSame([], $config_changelist['delete']);
++    $this->assertSame([], $config_changelist['rename']);
++    foreach ($collections as $collection) {
++      $config_changelist = $storage_comparer->getChangelist(NULL, $collection);
++      $this->assertSame([], $config_changelist['create']);
++      $this->assertSame([], $config_changelist['update']);
++      $this->assertSame(['config_collection_install_test.test'], $config_changelist['delete'], $collection);
++      $this->assertSame([], $config_changelist['rename']);
++    }
++
++    $importer->import();
++    $this->assertSame([], $importer->getErrors());
++
++    $checkpoint_storage = $this->container->get('config.storage.checkpoint');
++    /** @var \Drupal\Core\Config\StorageInterface $active_storage */
++    $active_storage = \Drupal::service('config.storage');
++    $this->assertEmpty($active_storage->getAllCollectionNames());
++    foreach ($collections as $collection) {
++      $collection_storage = $active_storage->createCollection($collection);
++      $this->assertFalse($collection_storage->read('config_collection_install_test.test'));
++    }
++
++    $checkpoint_storage->setCheckpointToReadFrom($check2);
++
++    $importer = $this->getConfigImporter($checkpoint_storage);
++
++    $storage_comparer = $importer->getStorageComparer();
++    $config_changelist = $storage_comparer->createChangelist()->getChangelist();
++    $this->assertSame([], $config_changelist['create']);
++    $this->assertSame(['core.extension'], $config_changelist['update']);
++    $this->assertSame([], $config_changelist['delete']);
++    $this->assertSame([], $config_changelist['rename']);
++    foreach ($collections as $collection) {
++      $config_changelist = $storage_comparer->getChangelist(NULL, $collection);
++      $this->assertSame(['config_collection_install_test.test'], $config_changelist['create']);
++      $this->assertSame([], $config_changelist['update']);
++      $this->assertSame([], $config_changelist['delete'], $collection);
++      $this->assertSame([], $config_changelist['rename']);
++    }
++    $importer->import();
++    $this->assertSame([], $importer->getErrors());
++
++    $this->assertTrue($this->container->get('module_handler')->moduleExists('config_collection_install_test'));
++    /** @var \Drupal\Core\Config\StorageInterface $active_storage */
++    $active_storage = \Drupal::service('config.storage');
++    $this->assertEquals($collections, $active_storage->getAllCollectionNames());
++    foreach ($collections as $collection) {
++      $collection_storage = $active_storage->createCollection($collection);
++      $data = $collection_storage->read('config_collection_install_test.test');
++      $this->assertEquals($collection, $data['collection']);
++    }
++  }
++
++  private function getConfigImporter(CheckpointStorageInterface $storage): ConfigImporter {
++    $storage_comparer = new StorageComparer(
++      $storage,
++      $this->container->get('config.storage')
++    );
++    return new ConfigImporter(
++      $storage_comparer,
++      $this->container->get('event_dispatcher'),
++      $this->container->get('config.manager'),
++      $this->container->get('lock'),
++      $this->container->get('config.typed'),
++      $this->container->get('module_handler'),
++      $this->container->get('module_installer'),
++      $this->container->get('theme_handler'),
++      $this->container->get('string_translation'),
++      $this->container->get('extension.list.module'),
++      $this->container->get('extension.list.theme')
++    );
++  }
++
++}
+diff --git a/core/tests/Drupal/KernelTests/Core/Recipe/ConfigConfiguratorTest.php b/core/tests/Drupal/KernelTests/Core/Recipe/ConfigConfiguratorTest.php
+new file mode 100644
+index 0000000000..b91ea75b37
+--- /dev/null
++++ b/core/tests/Drupal/KernelTests/Core/Recipe/ConfigConfiguratorTest.php
+@@ -0,0 +1,46 @@
++<?php
++
++declare(strict_types=1);
++
++namespace Drupal\KernelTests\Core\Recipe;
++
++use Drupal\Component\Serialization\Yaml;
++use Drupal\Core\Recipe\Recipe;
++use Drupal\KernelTests\KernelTestBase;
++
++/**
++ * @covers \Drupal\Core\Recipe\ConfigConfigurator
++ * @group Recipe
++ */
++class ConfigConfiguratorTest extends KernelTestBase {
++
++  public function testExistingConfigWithKeysInDifferentOrder(): void {
++    $recipe_dir = uniqid('public://recipe_test_');
++    mkdir($recipe_dir . '/config', recursive: TRUE);
++
++    $this->enableModules(['system']);
++    $this->installConfig('system');
++    /** @var mixed[][] $original_data */
++    $original_data = $this->config('system.site')->get();
++    // Remove keys that are ignored during the comparison.
++    unset($original_data['uuid'], $original_data['_core']);
++    $recipe_data = $original_data;
++    // Reorder an inner array, to ensure keys are sorted recursively.
++    $recipe_data['page'] = array_reverse($original_data['page'], TRUE);
++    $this->assertNotSame($original_data, $recipe_data);
++    file_put_contents($recipe_dir . '/config/system.site.yml', Yaml::encode($recipe_data));
++
++    $recipe = [
++      'name' => 'Same config, different order',
++      'type' => 'Testing',
++    ];
++    file_put_contents($recipe_dir . '/recipe.yml', Yaml::encode($recipe));
++
++    // If there was a conflict with the pre-existing config, ConfigConfigurator
++    // would throw an exception and the recipe would not be created. So all we
++    // need to do here is assert that, in fact, we were able to create a recipe
++    // object.
++    $this->assertInstanceOf(Recipe::class, Recipe::createFromDirectory($recipe_dir));
++  }
++
++}
+diff --git a/core/tests/Drupal/KernelTests/Core/Recipe/RecipeDiscoveryTest.php b/core/tests/Drupal/KernelTests/Core/Recipe/RecipeDiscoveryTest.php
+new file mode 100644
+index 0000000000..faf87866ee
+--- /dev/null
++++ b/core/tests/Drupal/KernelTests/Core/Recipe/RecipeDiscoveryTest.php
+@@ -0,0 +1,58 @@
++<?php
++
++namespace Drupal\KernelTests\Core\Recipe;
++
++use Drupal\Core\Recipe\RecipeDiscovery;
++use Drupal\Core\Recipe\UnknownRecipeException;
++use Drupal\KernelTests\KernelTestBase;
++
++/**
++ * @coversDefaultClass \Drupal\Core\Recipe\RecipeDiscovery
++ * @group Recipe
++ */
++class RecipeDiscoveryTest extends KernelTestBase {
++
++  public function providerRecipeDiscovery(): array {
++    return [
++      ['install_two_modules', 'Install two modules'],
++      ['recipe_include', 'Recipe include'],
++    ];
++  }
++
++  /**
++   * Tests that recipe discovery can find recipes.
++   *
++   * @dataProvider providerRecipeDiscovery
++   */
++  public function testRecipeDiscovery(string $recipe, string $name): void {
++    $discovery = new RecipeDiscovery(['core/tests/fixtures/recipes']);
++    $recipe = $discovery->getRecipe($recipe);
++    $this->assertSame($name, $recipe->name);
++  }
++
++  public function providerRecipeDiscoveryException(): array {
++    return [
++      'missing recipe.yml' => ['no_recipe'],
++      'no folder' => ['does_not_exist'],
++    ];
++  }
++
++  /**
++   * Tests the exception thrown when recipe discovery cannot find a recipe.
++   *
++   * @dataProvider providerRecipeDiscoveryException
++   */
++  public function testRecipeDiscoveryException(string $recipe): void {
++    $discovery = new RecipeDiscovery(['core/tests/fixtures/recipes']);
++    try {
++      $discovery->getRecipe($recipe);
++      $this->fail('Expected exception not thrown');
++    }
++    catch (UnknownRecipeException $e) {
++      $this->assertSame($recipe, $e->recipe);
++      $this->assertSame(['core/tests/fixtures/recipes'], $e->searchPaths);
++      $this->assertSame('Can not find the ' . $recipe . ' recipe, search paths: core/tests/fixtures/recipes', $e->getMessage());
++    }
++  }
++
++}
+diff --git a/core/tests/Drupal/KernelTests/Core/Recipe/RecipeRunnerTest.php b/core/tests/Drupal/KernelTests/Core/Recipe/RecipeRunnerTest.php
+new file mode 100644
+index 0000000000..f7042a78c7
+--- /dev/null
++++ b/core/tests/Drupal/KernelTests/Core/Recipe/RecipeRunnerTest.php
+@@ -0,0 +1,209 @@
++<?php
++
++namespace Drupal\KernelTests\Core\Recipe;
++
++use Drupal\Core\Recipe\Recipe;
++use Drupal\Core\Recipe\RecipePreExistingConfigException;
++use Drupal\Core\Recipe\RecipeRunner;
++use Drupal\Core\Recipe\RecipeUnmetDependenciesException;
++use Drupal\KernelTests\KernelTestBase;
++use Drupal\node\Entity\NodeType;
++use Drupal\views\Entity\View;
++
++/**
++ * @coversDefaultClass \Drupal\Core\Recipe\RecipeRunner
++ * @group Recipe
++ */
++class RecipeRunnerTest extends KernelTestBase {
++
++  public function testModuleInstall(): void {
++    // Test the state prior to applying the recipe.
++    $this->assertFalse($this->container->get('module_handler')->moduleExists('filter'), 'The filter module is not installed');
++    $this->assertFalse($this->container->get('module_handler')->moduleExists('text'), 'The text module is not installed');
++    $this->assertFalse($this->container->get('module_handler')->moduleExists('node'), 'The node module is not installed');
++    $this->assertFalse($this->container->get('config.storage')->exists('node.settings'), 'The node.settings configuration does not exist');
++
++    $recipe = Recipe::createFromDirectory('core/tests/fixtures/recipes/install_two_modules');
++    RecipeRunner::processRecipe($recipe);
++
++    // Test the state after applying the recipe.
++    $this->assertTrue($this->container->get('module_handler')->moduleExists('filter'), 'The filter module is installed');
++    $this->assertTrue($this->container->get('module_handler')->moduleExists('text'), 'The text module is installed');
++    $this->assertTrue($this->container->get('module_handler')->moduleExists('node'), 'The node module is installed');
++    $this->assertTrue($this->container->get('config.storage')->exists('node.settings'), 'The node.settings configuration has been created');
++    $this->assertFalse($this->config('node.settings')->get('use_admin_theme'), 'The node.settings:use_admin_theme is set to FALSE');
++  }
++
++  public function testModuleAndThemeInstall(): void {
++    $recipe = Recipe::createFromDirectory('core/tests/fixtures/recipes/base_theme_and_views');
++    RecipeRunner::processRecipe($recipe);
++
++    // Test the state after applying the recipe.
++    $this->assertTrue($this->container->get('module_handler')->moduleExists('views'), 'The views module is installed');
++    $this->assertTrue($this->container->get('module_handler')->moduleExists('node'), 'The node module is installed');
++    $this->assertTrue($this->container->get('theme_handler')->themeExists('test_basetheme'), 'The test_basetheme theme is installed');
++    $this->assertTrue($this->container->get('theme_handler')->themeExists('test_subtheme'), 'The test_subtheme theme is installed');
++    $this->assertTrue($this->container->get('theme_handler')->themeExists('test_subsubtheme'), 'The test_subsubtheme theme is installed');
++    $this->assertTrue($this->container->get('config.storage')->exists('node.settings'), 'The node.settings configuration has been created');
++    $this->assertFalse($this->container->get('config.storage')->exists('views.view.archive'), 'The views.view.archive configuration has not been created');
++    $this->assertEmpty(View::loadMultiple(), "No views exist");
++  }
++
++  public function testThemeModuleDependenciesInstall(): void {
++    $recipe = Recipe::createFromDirectory('core/tests/fixtures/recipes/theme_with_module_dependencies');
++    RecipeRunner::processRecipe($recipe);
++
++    // Test the state after applying the recipe.
++    $this->assertTrue($this->container->get('module_handler')->moduleExists('test_module_required_by_theme'), 'The test_module_required_by_theme module is installed');
++    $this->assertTrue($this->container->get('module_handler')->moduleExists('test_another_module_required_by_theme'), 'The test_another_module_required_by_theme module is installed');
++    $this->assertTrue($this->container->get('theme_handler')->themeExists('test_theme_depending_on_modules'), 'The test_theme_depending_on_modules theme is installed');
++  }
++
++  public function testModuleConfigurationOverride(): void {
++    // Test the state prior to applying the recipe.
++    $this->assertEmpty($this->container->get('config.factory')->listAll('node.'), 'There is no node configuration');
++
++    $recipe = Recipe::createFromDirectory('core/tests/fixtures/recipes/install_node_with_config');
++    RecipeRunner::processRecipe($recipe);
++
++    // Test the state after applying the recipe.
++    $this->assertTrue($this->container->get('config.storage')->exists('node.settings'), 'The node.settings configuration has been created');
++    $this->assertTrue($this->container->get('config.storage')->exists('node.settings'), 'The node.settings configuration has been created');
++    $this->assertTrue($this->config('node.settings')->get('use_admin_theme'), 'The node.settings:use_admin_theme is set to TRUE');
++    $this->assertSame('Test content type', NodeType::load('test')->label());
++    $node_type_data = $this->config('node.type.test')->get();
++    $this->assertGreaterThan(0, strlen($node_type_data['uuid']), 'The node type configuration has been assigned a UUID.');
++    // cSpell:disable-next-line
++    $this->assertSame('965SCwSA3qgVf47x7hEE4dufnUDpxKMsUfsqFtqjGn0', $node_type_data['_core']['default_config_hash']);
++  }
++
++  public function testUnmetConfigurationDependencies(): void {
++    $recipe = Recipe::createFromDirectory('core/tests/fixtures/recipes/unmet_config_dependencies');
++    try {
++      RecipeRunner::processRecipe($recipe);
++      $this->fail('Expected exception not thrown');
++    }
++    catch (RecipeUnmetDependenciesException $e) {
++      $this->assertSame("The configuration 'node.type.test' has unmet dependencies", $e->getMessage());
++      $this->assertSame('node.type.test', $e->configName);
++    }
++  }
++
++  public function testApplySameRecipe(): void {
++    // Test the state prior to applying the recipe.
++    $this->assertEmpty($this->container->get('config.factory')->listAll('node.'), 'There is no node configuration');
++
++    $recipe = Recipe::createFromDirectory('core/tests/fixtures/recipes/install_node_with_config');
++    RecipeRunner::processRecipe($recipe);
++
++    // Test the state prior to applying the recipe.
++    $this->assertNotEmpty($this->container->get('config.factory')->listAll('node.'), 'There is node configuration');
++
++    $recipe = Recipe::createFromDirectory('core/tests/fixtures/recipes/install_node_with_config');
++    RecipeRunner::processRecipe($recipe);
++    $this->assertTrue(TRUE, 'Applying a recipe for the second time with no config changes results in a successful application');
++
++    $type = NodeType::load('test');
++    $type->setNewRevision(FALSE);
++    $type->save();
++
++    $this->expectException(RecipePreExistingConfigException::class);
++    $this->expectExceptionMessage("The configuration 'node.type.test' exists already and does not match the recipe's configuration");
++    Recipe::createFromDirectory('core/tests/fixtures/recipes/install_node_with_config');
++  }
++
++  public function testConfigFromModule(): void {
++    // Test the state prior to applying the recipe.
++    $this->assertEmpty($this->container->get('config.factory')->listAll('config_test.'), 'There is no config_test configuration');
++
++    $recipe = Recipe::createFromDirectory('core/tests/fixtures/recipes/config_from_module');
++    RecipeRunner::processRecipe($recipe);
++
++    // Test the state after to applying the recipe.
++    $this->assertNotEmpty($this->container->get('config.factory')->listAll('config_test.'), 'There is config_test configuration');
++    $config_test_entities = \Drupal::entityTypeManager()->getStorage('config_test')->loadMultiple();
++    $this->assertSame(['dotted.default', 'override'], array_keys($config_test_entities));
++  }
++
++  public function testConfigWildcard(): void {
++    // Test the state prior to applying the recipe.
++    $this->assertEmpty($this->container->get('config.factory')->listAll('config_test.'), 'There is no config_test configuration');
++
++    $recipe = Recipe::createFromDirectory('core/tests/fixtures/recipes/config_wildcard');
++    RecipeRunner::processRecipe($recipe);
++
++    // Test the state after to applying the recipe.
++    $this->assertNotEmpty($this->container->get('config.factory')->listAll('config_test.'), 'There is config_test configuration');
++    $config_test_entities = \Drupal::entityTypeManager()->getStorage('config_test')->loadMultiple();
++    $this->assertSame(['dotted.default', 'override', 'override_unmet'], array_keys($config_test_entities));
++    $this->assertSame('Default', $config_test_entities['dotted.default']->label());
++    $this->assertSame('herp', $this->config('config_test.system')->get('404'));
++  }
++
++  public function testConfigFromModuleAndRecipe(): void {
++    // Test the state prior to applying the recipe.
++    $this->assertEmpty($this->container->get('config.factory')->listAll('config_test.'), 'There is no config_test configuration');
++
++    $recipe = Recipe::createFromDirectory('core/tests/fixtures/recipes/config_from_module_and_recipe');
++    RecipeRunner::processRecipe($recipe);
++
++    // Test the state after to applying the recipe.
++    $this->assertNotEmpty($this->container->get('config.factory')->listAll('config_test.'), 'There is config_test configuration');
++    $config_test_entities = \Drupal::entityTypeManager()->getStorage('config_test')->loadMultiple();
++    $this->assertSame(['dotted.default', 'override', 'override_unmet'], array_keys($config_test_entities));
++    $this->assertSame('Provided by recipe', $config_test_entities['dotted.default']->label());
++    $this->assertSame('foo', $this->config('config_test.system')->get('404'));
++  }
++
++  public function testRecipeInclude(): void {
++    // Test the state prior to applying the recipe.
++    $this->assertEmpty($this->container->get('config.factory')->listAll('node.'), 'There is no node configuration');
++    $this->assertFalse($this->container->get('module_handler')->moduleExists('dblog'), 'Dblog module not installed');
++
++    $recipe = Recipe::createFromDirectory('core/tests/fixtures/recipes/recipe_include');
++    RecipeRunner::processRecipe($recipe);
++
++    // Test the state after to applying the recipe.
++    $this->assertTrue($this->container->get('module_handler')->moduleExists('dblog'), 'Dblog module installed');
++    $this->assertSame('Test content type', NodeType::load('test')->label());
++    $this->assertSame('Another test content type', NodeType::load('another_test')->label());
++  }
++
++  public function testConfigActions() :void {
++    // Test the state prior to applying the recipe.
++    $this->assertEmpty($this->container->get('config.factory')->listAll('config_test.'), 'There is no config_test configuration');
++
++    $recipe = Recipe::createFromDirectory('core/tests/fixtures/recipes/config_actions');
++    RecipeRunner::processRecipe($recipe);
++
++    // Test the state after to applying the recipe.
++    $storage = \Drupal::entityTypeManager()->getStorage('config_test');
++    /** @var \Drupal\config_test\Entity\ConfigTest $config_test_entity */
++    $config_test_entity = $storage->load('recipe');
++    $this->assertSame('Created by recipe', $config_test_entity->label());
++    $this->assertSame('Set by recipe', $config_test_entity->getProtectedProperty());
++    $this->assertSame('not bar', $this->config('config_test.system')->get('foo'));
++  }
++
++  public function testConfigActionsPreExistingConfig() :void {
++    $this->enableModules(['config_test']);
++    $this->installConfig(['config_test']);
++    $this->assertSame('bar', $this->config('config_test.system')->get('foo'));
++    $storage = \Drupal::entityTypeManager()->getStorage('config_test');
++    /** @var \Drupal\config_test\Entity\ConfigTest $config_test_entity */
++    $config_test_entity = $storage->create(['id' => 'recipe', 'label' => 'Created by test']);
++    $config_test_entity->setProtectedProperty('Set by test');
++    $config_test_entity->save();
++
++    $recipe = Recipe::createFromDirectory('core/tests/fixtures/recipes/config_actions');
++    RecipeRunner::processRecipe($recipe);
++
++    // Test the state after to applying the recipe.
++    /** @var \Drupal\config_test\Entity\ConfigTest $config_test_entity */
++    $config_test_entity = $storage->load('recipe');
++    $this->assertSame('Created by test', $config_test_entity->label());
++    $this->assertSame('Set by recipe', $config_test_entity->getProtectedProperty());
++    $this->assertSame('not bar', $this->config('config_test.system')->get('foo'));
++  }
++
++}
+diff --git a/core/tests/Drupal/KernelTests/Core/Recipe/RecipeTest.php b/core/tests/Drupal/KernelTests/Core/Recipe/RecipeTest.php
+new file mode 100644
+index 0000000000..56a52fb877
+--- /dev/null
++++ b/core/tests/Drupal/KernelTests/Core/Recipe/RecipeTest.php
+@@ -0,0 +1,108 @@
++<?php
++
++namespace Drupal\KernelTests\Core\Recipe;
++
++use Drupal\Core\Recipe\Recipe;
++use Drupal\Core\Recipe\RecipeFileException;
++use Drupal\Core\Recipe\RecipeMissingExtensionsException;
++use Drupal\Core\Recipe\RecipePreExistingConfigException;
++use Drupal\Core\Recipe\UnknownRecipeException;
++use Drupal\KernelTests\KernelTestBase;
++
++/**
++ * @coversDefaultClass \Drupal\Core\Recipe\Recipe
++ * @group Recipe
++ */
++class RecipeTest extends KernelTestBase {
++
++  /**
++   * {@inheritdoc}
++   */
++  protected static $modules = ['system', 'user', 'field'];
++
++  public function providerTestCreateFromDirectory(): array {
++    return [
++      'no extensions' => ['no_extensions', 'No extensions' , 'Testing', [], 'A recipe description'],
++      // Filter is installed because it is a dependency and it is not yet installed.
++      'install_two_modules' => ['install_two_modules', 'Install two modules' , 'Content type', ['filter', 'text', 'node'], ''],
++    ];
++  }
++
++  /**
++   * @dataProvider providerTestCreateFromDirectory
++   */
++  public function testCreateFromDirectory2(string $recipe_name, string $expected_name, string $expected_type, array $expected_modules, string $expected_description): void {
++    $recipe = Recipe::createFromDirectory('core/tests/fixtures/recipes/' . $recipe_name);
++    $this->assertSame($expected_name, $recipe->name);
++    $this->assertSame($expected_type, $recipe->type);
++    $this->assertSame($expected_modules, $recipe->install->modules);
++    $this->assertSame($expected_description, $recipe->description);
++  }
++
++  public function testCreateFromDirectoryNoRecipe(): void {
++    $this->expectException(RecipeFileException::class);
++    $this->expectExceptionMessage('There is no core/tests/fixtures/recipes/no_recipe/recipe.yml file');
++    Recipe::createFromDirectory('core/tests/fixtures/recipes/no_recipe');
++  }
++
++  public function testCreateFromDirectoryNoRecipeName(): void {
++    $this->expectException(RecipeFileException::class);
++    $this->expectExceptionMessage('The core/tests/fixtures/recipes/no_name/recipe.yml has no name value.');
++    Recipe::createFromDirectory('core/tests/fixtures/recipes/no_name');
++  }
++
++  public function testCreateFromDirectoryMissingExtensions(): void {
++    $this->enableModules(['module_test']);
++
++    // Create a missing fake dependency.
++    // dblog will depend on Config, which depends on a non-existing module Foo.
++    // Nothing should be installed.
++    \Drupal::state()->set('module_test.dependency', 'missing dependency');
++
++    try {
++      Recipe::createFromDirectory('core/tests/fixtures/recipes/missing_extensions');
++      $this->fail('Expected exception not thrown');
++    }
++    catch (RecipeMissingExtensionsException $e) {
++      $this->assertSame(['does_not_exist_one', 'does_not_exist_two', 'foo'], $e->extensions);
++    }
++  }
++
++  public function testPreExistingDifferentConfiguration(): void {
++    // Install the node module, its dependencies and configuration.
++    $this->container->get('module_installer')->install(['node']);
++    $this->assertFalse($this->config('node.settings')->get('use_admin_theme'), 'The node.settings:use_admin_theme is set to FALSE');
++
++    try {
++      Recipe::createFromDirectory('core/tests/fixtures/recipes/install_node_with_config');
++      $this->fail('Expected exception not thrown');
++    }
++    catch (RecipePreExistingConfigException $e) {
++      $this->assertSame("The configuration 'node.settings' exists already and does not match the recipe's configuration", $e->getMessage());
++      $this->assertSame('node.settings', $e->configName);
++    }
++  }
++
++  public function testPreExistingMatchingConfiguration(): void {
++    // Install the node module, its dependencies and configuration.
++    $this->container->get('module_installer')->install(['node']);
++    // Change the config to match the recipe's config to prevent the exception
++    // being thrown.
++    $this->config('node.settings')->set('use_admin_theme', TRUE)->save();
++
++    $recipe = Recipe::createFromDirectory('core/tests/fixtures/recipes/install_node_with_config');
++    $this->assertSame('core/tests/fixtures/recipes/install_node_with_config/config', $recipe->config->recipeConfigDirectory);
++  }
++
++  public function testRecipeIncludeMissing(): void {
++    try {
++      Recipe::createFromDirectory('core/tests/fixtures/recipes/recipe_include_missing');
++    }
++    catch (UnknownRecipeException $e) {
++      $this->assertSame('does_not_exist', $e->recipe);
++      $this->assertSame(['core/tests/fixtures/recipes'], $e->searchPaths);
++      $this->assertSame('Can not find the does_not_exist recipe, search paths: core/tests/fixtures/recipes', $e->getMessage());
++    }
++  }
++
++}
+diff --git a/core/tests/Drupal/KernelTests/Core/Recipe/WildcardConfigActionsTest.php b/core/tests/Drupal/KernelTests/Core/Recipe/WildcardConfigActionsTest.php
+new file mode 100644
+index 0000000000..760f538fd3
+--- /dev/null
++++ b/core/tests/Drupal/KernelTests/Core/Recipe/WildcardConfigActionsTest.php
+@@ -0,0 +1,141 @@
++<?php
++
++declare(strict_types=1);
++
++namespace Drupal\KernelTests\Core\Recipe;
++
++use Drupal\Core\Config\Action\ConfigActionException;
++use Drupal\Core\Entity\EntityTypeManagerInterface;
++use Drupal\Core\Recipe\Recipe;
++use Drupal\Core\Recipe\RecipeRunner;
++use Drupal\entity_test\Entity\EntityTestBundle;
++use Drupal\field\Entity\FieldConfig;
++use Drupal\field\Entity\FieldStorageConfig;
++use Drupal\KernelTests\KernelTestBase;
++use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
++
++/**
++ * Tests config actions targeting multiple entities using wildcards.
++ *
++ * @group Recipe
++ */
++class WildcardConfigActionsTest extends KernelTestBase {
++
++  use ContentTypeCreationTrait;
++
++  /**
++   * {@inheritdoc}
++   */
++  protected static $modules = [
++    'entity_test',
++    'field',
++    'node',
++    'system',
++    'text',
++    'user',
++  ];
++
++  /**
++   * {@inheritdoc}
++   */
++  protected function setUp(): void {
++    parent::setUp();
++    $this->installConfig('node');
++
++    $this->createContentType(['type' => 'one']);
++    $this->createContentType(['type' => 'two']);
++
++    EntityTestBundle::create(['id' => 'one'])->save();
++    EntityTestBundle::create(['id' => 'two'])->save();
++
++    $field_storage = FieldStorageConfig::create([
++      'entity_type' => 'entity_test_with_bundle',
++      'field_name' => 'field_test',
++      'type' => 'boolean',
++    ]);
++    $field_storage->save();
++    FieldConfig::create(['field_storage' => $field_storage, 'bundle' => 'one'])
++      ->save();
++    FieldConfig::create(['field_storage' => $field_storage, 'bundle' => 'two'])
++      ->save();
++
++    $field_storage = FieldStorageConfig::create([
++      'entity_type' => 'node',
++      'field_name' => 'field_test',
++      'type' => 'boolean',
++    ]);
++    $field_storage->save();
++    FieldConfig::create(['field_storage' => $field_storage, 'bundle' => 'one'])
++      ->save();
++    FieldConfig::create(['field_storage' => $field_storage, 'bundle' => 'two'])
++      ->save();
++  }
++
++  /**
++   * Tests targeting multiple config entities for an action, using wildcards.
++   *
++   * @param string $expression
++   *   The expression the recipe will use to target multiple config entities.
++   * @param string[] $expected_changed_entities
++   *   The IDs of the config entities that we expect the recipe to change.
++   *
++   * @testWith ["field.field.node.one.*", ["node.one.body", "node.one.field_test"]]
++   *   ["field.field.node.*.body", ["node.one.body", "node.two.body"]]
++   *   ["field.field.*.one.field_test", ["entity_test_with_bundle.one.field_test", "node.one.field_test"]]
++   *   ["field.field.node.*.*", ["node.one.body", "node.one.field_test", "node.two.body", "node.two.field_test"]]
++   *   ["field.field.*.one.*", ["entity_test_with_bundle.one.field_test", "node.one.field_test", "node.one.body"]]
++   *   ["field.field.*.*.field_test", ["entity_test_with_bundle.one.field_test", "entity_test_with_bundle.two.field_test", "node.one.field_test", "node.two.field_test"]]
++   *   ["field.field.*.*.*", ["entity_test_with_bundle.one.field_test", "entity_test_with_bundle.two.field_test", "node.one.field_test", "node.two.field_test", "node.one.body", "node.two.body"]]
++   */
++  public function testTargetEntitiesByWildcards(string $expression, array $expected_changed_entities): void {
++    $contents = <<<YAML
++name: 'Wildcards!'
++config:
++  actions:
++    $expression:
++      setLabel: 'Changed by config action'
++YAML;
++
++    $dir = uniqid('public://');
++    mkdir($dir);
++    file_put_contents($dir . '/recipe.yml', $contents);
++    $recipe = Recipe::createFromDirectory($dir);
++    RecipeRunner::processRecipe($recipe);
++
++    $changed = $this->container->get(EntityTypeManagerInterface::class)
++      ->getStorage('field_config')
++      ->getQuery()
++      ->condition('label', 'Changed by config action')
++      ->execute();
++    sort($expected_changed_entities);
++    sort($changed);
++    $this->assertSame($expected_changed_entities, array_values($changed));
++  }
++
++  /**
++   * Tests that an invalid wildcard expression will raise an error.
++   *
++   * @testWith ["field.*.node.one.*", "No installed config entity type uses the prefix in the expression 'field.*.node.one.*'. Either there is a typo in the expression or this recipe should install an additional module or depend on another recipe."]
++   *   ["field.field.node.*.body/", " could not be parsed."]
++   */
++  public function testInvalidExpression(string $expression, string $expected_exception_message): void {
++    $contents = <<<YAML
++name: 'Wildcards gone wild...'
++config:
++  actions:
++    $expression:
++      simple_config_update:
++        label: 'Changed by config action'
++YAML;
++
++    $dir = uniqid('public://');
++    mkdir($dir);
++    file_put_contents($dir . '/recipe.yml', $contents);
++    $recipe = Recipe::createFromDirectory($dir);
++
++    $this->expectException(ConfigActionException::class);
++    $this->expectExceptionMessage($expected_exception_message);
++    RecipeRunner::processRecipe($recipe);
++  }
++
++}
+diff --git a/core/tests/Drupal/Tests/Core/Config/Checkpoint/CheckpointStorageTest.php b/core/tests/Drupal/Tests/Core/Config/Checkpoint/CheckpointStorageTest.php
+new file mode 100644
+index 0000000000..e79c307e5e
+--- /dev/null
++++ b/core/tests/Drupal/Tests/Core/Config/Checkpoint/CheckpointStorageTest.php
+@@ -0,0 +1,294 @@
++<?php
++
++declare(strict_types=1);
++
++namespace Drupal\Tests\Core\Config\Checkpoint;
++
++use Drupal\Component\Datetime\Time;
++use Drupal\Core\Config\Checkpoint\Checkpoint;
++use Drupal\Core\Config\Checkpoint\LinearHistory;
++use Drupal\Core\Config\Checkpoint\CheckpointStorage;
++use Drupal\Core\Config\Config;
++use Drupal\Core\Config\ConfigCrudEvent;
++use Drupal\Core\Config\MemoryStorage;
++use Drupal\Core\Config\StorageCopyTrait;
++use Drupal\Core\Config\StorageInterface;
++use Drupal\Core\KeyValueStore\KeyValueMemoryFactory;
++use Drupal\Core\State\State;
++use Drupal\Tests\UnitTestCase;
++use Drupal\TestTools\Random;
++
++/**
++ * @coversDefaultClass \Drupal\Core\Config\Checkpoint\CheckpointStorage
++ * @group Config
++ */
++class CheckpointStorageTest extends UnitTestCase {
++
++  use StorageCopyTrait;
++
++  /**
++   * The memory storage containing the data.
++   *
++   * @var \Drupal\Core\Config\MemoryStorage
++   */
++  protected MemoryStorage $memory;
++
++  /**
++   * The checkpoint storage under test.
++   *
++   * @var \Drupal\Core\Config\Checkpoint\CheckpointStorage
++   */
++  protected CheckpointStorage $storage;
++
++  /**
++   * {@inheritdoc}
++   */
++  protected function setUp(): void {
++    parent::setUp();
++
++    // Set up a memory storage we can manipulate to set fixtures.
++    $this->memory = new MemoryStorage();
++    $keyValueMemoryFactory = new KeyValueMemoryFactory();
++    $state = new State($keyValueMemoryFactory);
++    $time = new Time();
++    $checkpoints = new LinearHistory($state, $time);
++    $this->storage = new CheckpointStorage($this->memory, $checkpoints, $keyValueMemoryFactory);
++  }
++
++  /**
++   * @covers ::checkpoint
++   * @covers \Drupal\Core\Config\Checkpoint\Checkpoint
++   */
++  public function testCheckpointCreation(): void {
++    $checkpoint = $this->storage->checkpoint('Test');
++    $this->assertInstanceOf(Checkpoint::class, $checkpoint);
++    $this->assertSame('Test', $checkpoint->label);
++
++    $checkpoint2 = $this->storage->checkpoint('This will not make a checkpoint because nothing has changed');
++    $this->assertSame($checkpoint2, $checkpoint);
++    $config = $this->prophesize(Config::class);
++    $config->getName()->willReturn('test.config');
++    $config->getOriginal('', FALSE)->willReturn([]);
++    $config->getRawData()->willReturn(['foo' => 'bar']);
++    $config->getStorage()->willReturn($this->storage);
++    $event = new ConfigCrudEvent($config->reveal());
++    $this->storage->onConfigSaveAndDelete($event);
++
++    $checkpoint3 = $this->storage->checkpoint('Created test.config');
++    $this->assertNotSame($checkpoint3, $checkpoint);
++    $this->assertSame('Created test.config', $checkpoint3->label);
++
++    $checkpoint4 = $this->storage->checkpoint('This will not create a checkpoint either');
++    $this->assertSame($checkpoint4, $checkpoint3);
++
++    // Simulate a save with no change.
++    $config = $this->prophesize(Config::class);
++    $config->getName()->willReturn('test.config');
++    $config->getOriginal('', FALSE)->willReturn(['foo' => 'bar']);
++    $config->getRawData()->willReturn(['foo' => 'bar']);
++    $config->getStorage()->willReturn($this->storage);
++    $event = new ConfigCrudEvent($config->reveal());
++    $this->storage->onConfigSaveAndDelete($event);
++
++    $checkpoint5 = $this->storage->checkpoint('Save with no change');
++    $this->assertSame($checkpoint5, $checkpoint3);
++
++    // Create collection and ensure that checkpoints are kept in sync.
++    $collection = $this->storage->createCollection('test');
++    $config = $this->prophesize(Config::class);
++    $config->getName()->willReturn('test.config');
++    $config->getOriginal('', FALSE)->willReturn(['foo' => 'bar']);
++    $config->getRawData()->willReturn(['foo' => 'collection_bar']);
++    $config->getStorage()->willReturn($collection);
++    $event = new ConfigCrudEvent($config->reveal());
++    $collection->onConfigSaveAndDelete($event);
++
++    $checkpoint6 = $this->storage->checkpoint('Save in collection');
++    $this->assertNotSame($checkpoint6, $checkpoint3);
++    $this->assertSame($collection->checkpoint('Calling checkpoint on collection'), $checkpoint6);
++  }
++
++  /**
++   * @covers ::exists
++   * @covers ::read
++   * @covers ::readMultiple
++   * @covers ::listAll
++   *
++   * @dataProvider readMethodsProvider
++   */
++  public function testReadOperations(string $method, array $arguments, array $fixture): void {
++    // Create a checkpoint so the checkpoint storage can be read from.
++    $this->storage->checkpoint('');
++    $this->setRandomFixtureConfig($fixture);
++
++    $expected = call_user_func_array([$this->memory, $method], $arguments);
++    $actual = call_user_func_array([$this->storage, $method], $arguments);
++    $this->assertEquals($expected, $actual);
++  }
++
++  /**
++   * Provide the methods that work transparently.
++   *
++   * @return array
++   *   The data.
++   */
++  public function readMethodsProvider(): array {
++    $fixture = [
++      StorageInterface::DEFAULT_COLLECTION => ['config.a', 'config.b', 'other.a'],
++    ];
++
++    $data = [];
++    $data[] = ['exists', ['config.a'], $fixture];
++    $data[] = ['exists', ['not.existing'], $fixture];
++    $data[] = ['read', ['config.a'], $fixture];
++    $data[] = ['read', ['not.existing'], $fixture];
++    $data[] = ['readMultiple', [['config.a', 'config.b', 'not']], $fixture];
++    $data[] = ['listAll', [''], $fixture];
++    $data[] = ['listAll', ['config'], $fixture];
++    $data[] = ['listAll', ['none'], $fixture];
++
++    return $data;
++  }
++
++  /**
++   * @covers ::write
++   * @covers ::delete
++   * @covers ::rename
++   * @covers ::deleteAll
++   *
++   * @dataProvider writeMethodsProvider
++   */
++  public function testWriteOperations(string $method, array $arguments, array $fixture): void {
++    $this->setRandomFixtureConfig($fixture);
++
++    // Create an independent memory storage as a backup.
++    $backup = new MemoryStorage();
++    static::replaceStorageContents($this->memory, $backup);
++
++    try {
++      call_user_func_array([$this->storage, $method], $arguments);
++      $this->fail("exception not thrown");
++    }
++    catch (\BadMethodCallException $exception) {
++      $this->assertEquals(CheckpointStorage::class . '::' . $method . ' is not allowed on a CheckpointStorage', $exception->getMessage());
++    }
++
++    // Assert that the memory storage has not been altered.
++    $this->assertEquals($backup, $this->memory);
++  }
++
++  /**
++   * Provide the methods that throw an exception.
++   *
++   * @return array
++   *   The data
++   */
++  public static function writeMethodsProvider(): array {
++    $fixture = [
++      StorageInterface::DEFAULT_COLLECTION => ['config.a', 'config.b'],
++    ];
++
++    $data = [];
++    $data[] = ['write', ['config.a', (array) Random::getGenerator()->object()], $fixture];
++    $data[] = ['write', [Random::MachineName(), (array) Random::getGenerator()->object()], $fixture];
++    $data[] = ['delete', ['config.a'], $fixture];
++    $data[] = ['delete', [Random::MachineName()], $fixture];
++    $data[] = ['rename', ['config.a', 'config.b'], $fixture];
++    $data[] = ['rename', ['config.a', Random::MachineName()], $fixture];
++    $data[] = ['rename', [Random::MachineName(), Random::MachineName()], $fixture];
++    $data[] = ['deleteAll', [''], $fixture];
++    $data[] = ['deleteAll', ['config'], $fixture];
++    $data[] = ['deleteAll', ['other'], $fixture];
++
++    return $data;
++  }
++
++  /**
++   * @covers ::getAllCollectionNames
++   * @covers ::getCollectionName
++   * @covers ::createCollection
++   */
++  public function testCollections(): void {
++    $ref_readFromCheckpoint = new \ReflectionProperty($this->storage, 'readFromCheckpoint');
++
++    // Create some checkpoints so the checkpoint storage can be read from.
++    $checkpoint1 = $this->storage->checkpoint('1');
++    $config = $this->prophesize(Config::class);
++    $config->getName()->willReturn('test.config');
++    $config->getOriginal('', FALSE)->willReturn([]);
++    $config->getRawData()->willReturn(['foo' => 'bar']);
++    $config->getStorage()->willReturn($this->storage);
++    $event = new ConfigCrudEvent($config->reveal());
++    $this->storage->onConfigSaveAndDelete($event);
++    $checkpoint2 = $this->storage->checkpoint('2');
++
++    $fixture = [
++      StorageInterface::DEFAULT_COLLECTION => [$this->randomMachineName()],
++      'A' => [$this->randomMachineName()],
++      'B' => [$this->randomMachineName()],
++      'C' => [$this->randomMachineName()],
++    ];
++    $this->setRandomFixtureConfig($fixture);
++
++    $this->assertEquals(['A', 'B', 'C'], $this->storage->getAllCollectionNames());
++    foreach (array_keys($fixture) as $collection) {
++      $storage = $this->storage->createCollection($collection);
++      // Assert that the collection storage is still a checkpoint storage.
++      $this->assertInstanceOf(CheckpointStorage::class, $storage);
++      $this->assertEquals($collection, $storage->getCollectionName());
++
++      // Ensure that the
++      // \Drupal\Core\Config\Checkpoint\CheckpointStorage::$readFromCheckpoint
++      // property is kept in sync.
++      $this->storage->setCheckpointToReadFrom($checkpoint2);
++      $this->assertSame($checkpoint2->id, $ref_readFromCheckpoint->getValue($storage->createCollection($collection))?->id);
++      if (isset($previous_collection)) {
++        $previous_collection->setCheckpointToReadFrom($checkpoint1);
++        $this->assertSame($checkpoint1->id, $ref_readFromCheckpoint->getValue($storage->createCollection($collection))?->id);
++        $this->assertSame($checkpoint1->id, $ref_readFromCheckpoint->getValue($this->storage->createCollection($collection))?->id);
++      }
++
++      // Save the storage in a variable so we can test use
++      // setCheckpointToReadFrom() on it.
++      $previous_collection = $storage;
++    }
++  }
++
++  /**
++   * @covers ::encode
++   * @covers ::decode
++   */
++  public function testEncodeDecode(): void {
++    $array = (array) $this->getRandomGenerator()->object();
++    $string = $this->getRandomGenerator()->string();
++
++    // Assert reversibility of encoding and decoding.
++    $this->assertEquals($array, $this->storage->decode($this->storage->encode($array)));
++    $this->assertEquals($string, $this->storage->encode($this->storage->decode($string)));
++    // Assert same results as the decorated storage.
++    $this->assertEquals($this->memory->encode($array), $this->storage->encode($array));
++    $this->assertEquals($this->memory->decode($string), $this->storage->decode($string));
++  }
++
++  /**
++   * Generate random config in the memory storage.
++   *
++   * @param array $config
++   *   The config keys, keyed by the collection.
++   */
++  protected function setRandomFixtureConfig(array $config): void {
++    // Erase previous fixture.
++    foreach (array_merge([StorageInterface::DEFAULT_COLLECTION], $this->memory->getAllCollectionNames()) as $collection) {
++      $this->memory->createCollection($collection)->deleteAll();
++    }
++
++    foreach ($config as $collection => $keys) {
++      $storage = $this->memory->createCollection($collection);
++      foreach ($keys as $key) {
++        // Create some random config.
++        $storage->write($key, (array) $this->getRandomGenerator()->object());
++      }
++    }
++  }
++
++}
+diff --git a/core/tests/Drupal/Tests/Core/Config/Checkpoint/LinearHistoryTest.php b/core/tests/Drupal/Tests/Core/Config/Checkpoint/LinearHistoryTest.php
+new file mode 100644
+index 0000000000..1a3ee6cd7c
+--- /dev/null
++++ b/core/tests/Drupal/Tests/Core/Config/Checkpoint/LinearHistoryTest.php
+@@ -0,0 +1,190 @@
++<?php
++
++declare(strict_types=1);
++
++namespace Drupal\Tests\Core\Config\Checkpoint;
++
++use Drupal\Component\Datetime\TimeInterface;
++use Drupal\Component\Render\FormattableMarkup;
++use Drupal\Core\Config\Checkpoint\Checkpoint;
++use Drupal\Core\Config\Checkpoint\CheckpointExistsException;
++use Drupal\Core\Config\Checkpoint\UnknownCheckpointException;
++use Drupal\Core\Config\Checkpoint\LinearHistory;
++use Drupal\Core\State\StateInterface;
++use Drupal\Tests\UnitTestCase;
++use Prophecy\Argument;
++
++/**
++ * @coversDefaultClass \Drupal\Core\Config\Checkpoint\LinearHistory
++ * @group Config
++ */
++class LinearHistoryTest extends UnitTestCase {
++
++  /**
++   * The key used store of all the checkpoint names in state.
++   *
++   * @see \Drupal\Core\Config\Checkpoint\Checkpoints::CHECKPOINT_KEY
++   */
++  private const CHECKPOINT_KEY = 'config.checkpoints';
++
++  /**
++   * @covers ::add
++   * @covers ::count
++   * @covers ::getActiveCheckpoint
++   * @covers \Drupal\Core\Config\Checkpoint\Checkpoint
++   */
++  public function testAdd(): void {
++    $state = $this->prophesize(StateInterface::class);
++    $state->get(self::CHECKPOINT_KEY, [])->willReturn([]);
++    $state->set(self::CHECKPOINT_KEY, Argument::any())->willReturn(NULL);
++    $time = $this->prophesize(TimeInterface::class);
++    $time->getCurrentTime()->willReturn(1701539520, 1701539994);
++    $checkpoints = new LinearHistory($state->reveal(), $time->reveal());
++
++    $this->assertCount(0, $checkpoints);
++    $this->assertNull($checkpoints->getActiveCheckpoint());
++
++    $checkpoint = $checkpoints->add('hash1', 'Label');
++
++    $this->assertSame('hash1', $checkpoint->id);
++    $this->assertSame('Label', $checkpoint->label);
++    $this->assertNull($checkpoint->parent);
++    $this->assertSame(1701539520, $checkpoint->timestamp);
++
++    $this->assertCount(1, $checkpoints);
++    $this->assertSame('hash1', $checkpoints->getActiveCheckpoint()?->id);
++
++    // Test that on the second call to add the ancestor is set correctly.
++    $checkpoint2 = $checkpoints->add('hash2', new FormattableMarkup('Another label', []));
++    $this->assertSame('hash2', $checkpoint2->id);
++    $this->assertSame('Another label', (string) $checkpoint2->label);
++    $this->assertSame($checkpoint->id, $checkpoint2->parent);
++    $this->assertSame(1701539994, $checkpoint2->timestamp);
++
++    $this->assertCount(2, $checkpoints);
++    $this->assertSame('hash2', $checkpoints->getActiveCheckpoint()?->id);
++
++    // Test that the checkpoints object can be iterated over.
++    $i = 0;
++    foreach ($checkpoints as $value) {
++      $i++;
++      $this->assertInstanceOf(Checkpoint::class, $value);
++      $this->assertSame('hash' . $i, $value->id);
++    }
++  }
++
++  /**
++   * @covers ::add
++   */
++  public function testAddException(): void {
++    $state = $this->prophesize(StateInterface::class);
++    $state->get(self::CHECKPOINT_KEY, [])->willReturn([]);
++    $state->set(self::CHECKPOINT_KEY, Argument::any())->willReturn(NULL);
++    $time = $this->prophesize(TimeInterface::class);
++    $time->getCurrentTime()->willReturn(1701539520, 1701539994);
++    $checkpoints = new LinearHistory($state->reveal(), $time->reveal());
++    $checkpoints->add('hash1', 'Label');
++    // Add another checkpoint with the same ID and an exception should be
++    // triggered.
++    $this->expectException(CheckpointExistsException::class);
++    $this->expectExceptionMessage('Cannot create a checkpoint with the ID "hash1" as it already exists');
++    $checkpoints->add('hash1', 'Label');
++  }
++
++  /**
++   * @covers ::delete
++   */
++  public function testDeleteAll(): void {
++    $state = $this->prophesize(StateInterface::class);
++    $state->get(self::CHECKPOINT_KEY, [])->willReturn([
++      'hash1' => new Checkpoint('hash1', 'One', 1701539510, NULL),
++      'hash2' => new Checkpoint('hash2', 'Two', 1701539520, 'hash1'),
++      'hash3' => new Checkpoint('hash3', 'Three', 1701539530, 'hash2'),
++    ]);
++    $state->delete(self::CHECKPOINT_KEY)->willReturn();
++    $time = $this->prophesize(TimeInterface::class);
++    $checkpoints = new LinearHistory($state->reveal(), $time->reveal());
++
++    $this->assertCount(3, $checkpoints);
++    $this->assertSame('hash3', $checkpoints->getActiveCheckpoint()?->id);
++    $checkpoints->deleteAll();
++    $this->assertCount(0, $checkpoints);
++    $this->assertNull($checkpoints->getActiveCheckpoint());
++  }
++
++  /**
++   * @covers ::delete
++   */
++  public function testDelete(): void {
++    $state = $this->prophesize(StateInterface::class);
++    $test_data = [
++      'hash1' => new Checkpoint('hash1', 'One', 1701539510, NULL),
++      'hash2' => new Checkpoint('hash2', 'Two', 1701539520, 'hash1'),
++      'hash3' => new Checkpoint('hash3', 'Three', 1701539530, 'hash2'),
++    ];
++    $state->get(self::CHECKPOINT_KEY, [])->willReturn($test_data);
++    unset($test_data['hash1'], $test_data['hash2']);
++    $state->set(self::CHECKPOINT_KEY, $test_data)->willReturn();
++    $time = $this->prophesize(TimeInterface::class);
++    $checkpoints = new LinearHistory($state->reveal(), $time->reveal());
++
++    $this->assertCount(3, $checkpoints);
++    $this->assertSame('hash3', $checkpoints->getActiveCheckpoint()?->id);
++    $checkpoints->delete('hash2');
++    $this->assertCount(1, $checkpoints);
++    $this->assertSame('hash3', $checkpoints->getActiveCheckpoint()?->id);
++  }
++
++  /**
++   * @covers ::delete
++   */
++  public function testDeleteException(): void {
++    $state = $this->prophesize(StateInterface::class);
++    $state->get(self::CHECKPOINT_KEY, [])->willReturn([]);
++    $time = $this->prophesize(TimeInterface::class);
++    $checkpoints = new LinearHistory($state->reveal(), $time->reveal());
++
++    $this->expectException(UnknownCheckpointException::class);
++    $this->expectExceptionMessage('Cannot delete a checkpoint with the ID "foo" as it does not exist');
++
++    $checkpoints->delete('foo');
++  }
++
++  /**
++   * @covers ::getParents
++   */
++  public function testGetParents(): void {
++    $state = $this->prophesize(StateInterface::class);
++    $test_data = [
++      'hash1' => new Checkpoint('hash1', 'One', 1701539510, NULL),
++      'hash2' => new Checkpoint('hash2', 'Two', 1701539520, 'hash1'),
++      'hash3' => new Checkpoint('hash3', 'Three', 1701539530, 'hash2'),
++    ];
++    $state->get(self::CHECKPOINT_KEY, [])->willReturn($test_data);
++    $time = $this->prophesize(TimeInterface::class);
++    $checkpoints = new LinearHistory($state->reveal(), $time->reveal());
++
++    $this->assertSame(['hash2' => $test_data['hash2'], 'hash1' => $test_data['hash1']], iterator_to_array($checkpoints->getParents('hash3')));
++    $this->assertSame(['hash1' => $test_data['hash1']], iterator_to_array($checkpoints->getParents('hash2')));
++    $this->assertSame([], iterator_to_array($checkpoints->getParents('hash1')));
++  }
++
++  /**
++   * @covers ::getParents
++   */
++  public function testGetParentsException(): void {
++    $state = $this->prophesize(StateInterface::class);
++    $test_data = [
++      'hash1' => new Checkpoint('hash1', 'One', 1701539510, NULL),
++      'hash2' => new Checkpoint('hash2', 'Two', 1701539520, 'hash1'),
++    ];
++    $state->get(self::CHECKPOINT_KEY, [])->willReturn($test_data);
++    $time = $this->prophesize(TimeInterface::class);
++    $checkpoints = new LinearHistory($state->reveal(), $time->reveal());
++
++    $this->expectException(UnknownCheckpointException::class);
++    $this->expectExceptionMessage('The checkpoint "hash3" does not exist');
++    iterator_to_array($checkpoints->getParents('hash3'));
++  }
++
++}
+diff --git a/core/tests/Drupal/Tests/Core/Recipe/RecipeConfigStorageWrapperTest.php b/core/tests/Drupal/Tests/Core/Recipe/RecipeConfigStorageWrapperTest.php
+new file mode 100644
+index 0000000000..b74c14d8b4
+--- /dev/null
++++ b/core/tests/Drupal/Tests/Core/Recipe/RecipeConfigStorageWrapperTest.php
+@@ -0,0 +1,324 @@
++<?php
++
++declare(strict_types=1);
++
++namespace Drupal\Tests\Core\Recipe;
++
++use Drupal\Core\Config\MemoryStorage;
++use Drupal\Core\Config\NullStorage;
++use Drupal\Core\Config\StorageInterface;
++use Drupal\Core\Recipe\RecipeConfigStorageWrapper;
++use Drupal\Tests\UnitTestCase;
++
++/**
++ * @coversDefaultClass \Drupal\Core\Recipe\RecipeConfigStorageWrapper
++ * @group Recipe
++ */
++class RecipeConfigStorageWrapperTest extends UnitTestCase {
++
++  /**
++   * Validate that an empty set of storage backends returns null storage.
++   */
++  public function testNullStorage(): void {
++    $this->assertInstanceOf(
++      NullStorage::class,
++      RecipeConfigStorageWrapper::createStorageFromArray([])
++    );
++  }
++
++  /**
++   * Validate that a single storage returns exactly the same instance.
++   */
++  public function testSingleStorage(): void {
++    $storages = [new NullStorage()];
++    $this->assertSame(
++      $storages[0],
++      RecipeConfigStorageWrapper::createStorageFromArray($storages)
++    );
++  }
++
++  /**
++   * Validate that multiple storages return underlying values correctly.
++   */
++  public function testMultipleStorages(): void {
++    $a = new MemoryStorage();
++    $a->write('a_key', ['a_data_first']);
++    $b = new MemoryStorage();
++
++    // Add a conflicting key so that we can test the first value is returned.
++    $b->write('a_key', ['a_data_second']);
++    $b->write('b_key', ['b_data']);
++
++    // We test with a third storage as well since only two storages can be done
++    // via the constructor alone.
++    $c = new MemoryStorage();
++    $c->write('c_key', ['c_data']);
++
++    $storages = [$a, $b, $c];
++    $wrapped = RecipeConfigStorageWrapper::createStorageFromArray($storages);
++
++    $this->assertSame($a->read('a_key'), $wrapped->read('a_key'));
++    $this->assertNotEquals($b->read('a_key'), $wrapped->read('a_key'));
++    $this->assertSame($b->read('b_key'), $wrapped->read('b_key'));
++    $this->assertSame($c->read('c_key'), $wrapped->read('c_key'));
++  }
++
++  /**
++   * Validate that the first storage checks existence first.
++   */
++  public function testLeftSideExists(): void {
++    $a = $this->createMock(StorageInterface::class);
++    $a->expects($this->once())->method('exists')->with('a_key')
++      ->willReturn(TRUE);
++    $b = $this->createMock(StorageInterface::class);
++    $b->expects($this->never())->method('exists');
++
++    $storage = new RecipeConfigStorageWrapper($a, $b);
++    $this->assertTrue($storage->exists('a_key'));
++  }
++
++  /**
++   * Validate that we fall back to the second storage.
++   */
++  public function testRightSideExists(): void {
++    [$a, $b] = $this->generateStorages(TRUE);
++
++    $storage = new RecipeConfigStorageWrapper($a, $b);
++    $storage->exists('a_key');
++  }
++
++  /**
++   * Validate FALSE when neither storage contains a key.
++   */
++  public function testNotExists(): void {
++    [$a, $b] = $this->generateStorages(FALSE);
++
++    $storage = new RecipeConfigStorageWrapper($a, $b);
++    $this->assertFalse($storage->exists('a_key'));
++  }
++
++  /**
++   * Validate that we read from storage A first.
++   */
++  public function testReadFromA(): void {
++    $a = $this->createMock(StorageInterface::class);
++    $value = ['a_value'];
++    $a->expects($this->once())->method('read')->with('a_key')
++      ->willReturn($value);
++    $b = $this->createMock(StorageInterface::class);
++    $b->expects($this->never())->method('read');
++
++    $storage = new RecipeConfigStorageWrapper($a, $b);
++    $this->assertSame($value, $storage->read('a_key'));
++  }
++
++  /**
++   * Validate that we read from storage B second.
++   */
++  public function testReadFromB(): void {
++    $a = $this->createMock(StorageInterface::class);
++    $a->expects($this->once())->method('read')->with('a_key')
++      ->willReturn(FALSE);
++    $b = $this->createMock(StorageInterface::class);
++    $value = ['a_value'];
++    $b->expects($this->once())->method('read')->with('a_key')
++      ->willReturn($value);
++
++    $storage = new RecipeConfigStorageWrapper($a, $b);
++    $this->assertSame($value, $storage->read('a_key'));
++  }
++
++  /**
++   * Validate when neither storage can read a value.
++   */
++  public function testReadFails(): void {
++    $a = $this->createMock(StorageInterface::class);
++    $a->expects($this->once())->method('read')->with('a_key')
++      ->willReturn(FALSE);
++    $b = $this->createMock(StorageInterface::class);
++    $b->expects($this->once())->method('read')->with('a_key')
++      ->willReturn(FALSE);
++
++    $storage = new RecipeConfigStorageWrapper($a, $b);
++    $this->assertFalse($storage->read('a_key'));
++  }
++
++  /**
++   * Test reading multiple values.
++   */
++  public function testReadMultiple(): void {
++    $a = $this->createMock(StorageInterface::class);
++    $a->expects($this->once())->method('readMultiple')->with(['a_key', 'b_key'])
++      ->willReturn(['a_key' => ['a_value']]);
++    $b = $this->createMock(StorageInterface::class);
++    $b->expects($this->once())->method('readMultiple')->with(['a_key', 'b_key'])
++      ->willReturn(['b_key' => ['b_value']]);
++
++    $storage = new RecipeConfigStorageWrapper($a, $b);
++    $this->assertEquals([
++      'a_key' => ['a_value'],
++      'b_key' => ['b_value'],
++    ], $storage->readMultiple(['a_key', 'b_key']));
++  }
++
++  /**
++   * Test that storage A has precedence over storage B.
++   */
++  public function testReadMultipleStorageA(): void {
++    $a = $this->createMock(StorageInterface::class);
++    $a->expects($this->once())->method('readMultiple')->with(['a_key', 'b_key'])
++      ->willReturn(['a_key' => ['a_value']]);
++    $b = $this->createMock(StorageInterface::class);
++    $b->expects($this->once())->method('readMultiple')->with(['a_key', 'b_key'])
++      ->willReturn(['a_key' => ['a_conflicting_value'], 'b_key' => ['b_value']]);
++
++    $storage = new RecipeConfigStorageWrapper($a, $b);
++    $this->assertEquals([
++      'a_key' => ['a_value'],
++      'b_key' => ['b_value'],
++    ], $storage->readMultiple(['a_key', 'b_key']));
++  }
++
++  /**
++   * Test methods that are unsupported.
++   *
++   * @param string $method
++   *   The method to call.
++   * @param array $args
++   *   The arguments to pass to the method.
++   *
++   * @dataProvider unsupportedMethods
++   */
++  public function testUnsupportedMethods(string $method, ...$args): void {
++    $this->expectException(\BadMethodCallException::class);
++    $storage = new RecipeConfigStorageWrapper(new NullStorage(), new NullStorage());
++    $storage->{$method}(...$args);
++  }
++
++  /**
++   * Test that we only use storage A's encode method.
++   */
++  public function testEncode(): void {
++    $a = $this->createMock(StorageInterface::class);
++    $data = 'value';
++    $a->expects($this->once())->method('encode')->with([$data])
++      ->willReturn($data);
++    $b = $this->createMock(StorageInterface::class);
++    $b->expects($this->never())->method('encode');
++    $storage = new RecipeConfigStorageWrapper($a, $b);
++    $this->assertSame($data, $storage->encode([$data]));
++  }
++
++  /**
++   * Test that we only use storage A's decode method.
++   */
++  public function testDecode(): void {
++    $a = $this->createMock(StorageInterface::class);
++    $raw = 'value';
++    $a->expects($this->once())->method('decode')->with($raw)
++      ->willReturn([$raw]);
++    $b = $this->createMock(StorageInterface::class);
++    $b->expects($this->never())->method('decode');
++    $storage = new RecipeConfigStorageWrapper($a, $b);
++    $this->assertEquals([$raw], $storage->decode($raw));
++  }
++
++  /**
++   * Test that list all merges values and makes them unique.
++   */
++  public function testListAll(): void {
++    $a = $this->createMock(StorageInterface::class);
++    $a->method('listAll')->with('node.')
++      ->willReturn(['node.type']);
++    $b = $this->createMock(StorageInterface::class);
++    $b->method('listAll')->with('node.')
++      ->willReturn(['node.type', 'node.id']);
++    $storage = new RecipeConfigStorageWrapper($a, $b);
++    $this->assertEquals([
++      0 => 'node.type',
++      2 => 'node.id',
++    ], $storage->listAll('node.'));
++  }
++
++  /**
++   * Test creating a collection passes the name through to the child storages.
++   */
++  public function testCreateCollection(): void {
++    $collection_name = 'collection';
++    $a = $this->createMock(StorageInterface::class);
++    $b = $this->createMock(StorageInterface::class);
++    /** @var \PHPUnit\Framework\MockObject\MockObject $mock */
++    foreach ([$a, $b] as $mock) {
++      $mock->expects($this->once())->method('createCollection')
++        ->with($collection_name)->willReturn(new NullStorage($collection_name));
++    }
++    $storage = new RecipeConfigStorageWrapper($a, $b);
++    $new = $storage->createCollection($collection_name);
++    $this->assertInstanceOf(RecipeConfigStorageWrapper::class, $new);
++    $this->assertEquals($collection_name, $new->getCollectionName());
++    $this->assertNotEquals($storage, $new);
++  }
++
++  /**
++   * Test that we merge and return only unique collection names.
++   */
++  public function testGetAllCollectionNames(): void {
++    $a = $this->createMock(StorageInterface::class);
++    $a->expects($this->once())->method('getAllCollectionNames')
++      ->willReturn(['collection_1', 'collection_2']);
++    $b = $this->createMock(StorageInterface::class);
++    $b->expects($this->once())->method('getAllCollectionNames')
++      ->willReturn(['collection_3', 'collection_1', 'collection_2']);
++    $storage = new RecipeConfigStorageWrapper($a, $b);
++    $this->assertEquals([
++      'collection_1',
++      'collection_2',
++      'collection_3',
++    ], $storage->getAllCollectionNames());
++  }
++
++  /**
++   * Test the collection name is stored properly.
++   */
++  public function testGetCollection(): void {
++    $a = $this->createMock(StorageInterface::class);
++    $b = $this->createMock(StorageInterface::class);
++    $storage = new RecipeConfigStorageWrapper($a, $b, 'collection');
++    $this->assertEquals('collection', $storage->getCollectionName());
++  }
++
++  /**
++   * Generate two storages where the second storage should return a value.
++   *
++   * @param bool $b_return
++   *   The return value for storage $b's exist method.
++   *
++   * @return \Drupal\Core\Config\StorageInterface[]
++   *   An array of two mocked storages.
++   */
++  private function generateStorages(bool $b_return): array {
++    $a = $this->createMock(StorageInterface::class);
++    $a->expects($this->once())->method('exists')->with('a_key')
++      ->willReturn(FALSE);
++    $b = $this->createMock(StorageInterface::class);
++    $b->expects($this->once())->method('exists')->with('a_key')
++      ->willReturn($b_return);
++    return [$a, $b];
++  }
++
++  /**
++   * Data provider for methods that are unsupported.
++   *
++   * @return array
++   *   An array of method names w/ args to test the unsupported methods.
++   */
++  public function unsupportedMethods(): array {
++    return [
++      ['write', 'name', []],
++      ['delete', 'name'],
++      ['rename', 'old_name', 'new_name'],
++      ['deleteAll'],
++    ];
++  }
++
++}
+diff --git a/core/tests/fixtures/recipes/base_theme_and_views/recipe.yml b/core/tests/fixtures/recipes/base_theme_and_views/recipe.yml
+new file mode 100644
+index 0000000000..6d9589f9c3
+--- /dev/null
++++ b/core/tests/fixtures/recipes/base_theme_and_views/recipe.yml
+@@ -0,0 +1,6 @@
++name: 'Base theme and views'
++type: 'Testing'
++install:
++  - test_subsubtheme
++  - node
++  - views
+diff --git a/core/tests/fixtures/recipes/config_actions/recipe.yml b/core/tests/fixtures/recipes/config_actions/recipe.yml
+new file mode 100644
+index 0000000000..4e16eeb67b
+--- /dev/null
++++ b/core/tests/fixtures/recipes/config_actions/recipe.yml
+@@ -0,0 +1,13 @@
++name: 'Config actions'
++type: 'Testing'
++install:
++  - config_test
++config:
++  actions:
++    config_test.dynamic.recipe:
++      ensure_exists:
++        label: 'Created by recipe'
++      setProtectedProperty: 'Set by recipe'
++    config_test.system:
++      simple_config_update:
++        foo: 'not bar'
+diff --git a/core/tests/fixtures/recipes/config_from_module/recipe.yml b/core/tests/fixtures/recipes/config_from_module/recipe.yml
+new file mode 100644
+index 0000000000..f88aa486c1
+--- /dev/null
++++ b/core/tests/fixtures/recipes/config_from_module/recipe.yml
+@@ -0,0 +1,9 @@
++name: 'Config from module'
++type: 'Testing'
++install:
++  - config_test
++config:
++  import:
++    config_test:
++      - config_test.dynamic.dotted.default
++      - config_test.dynamic.override
+diff --git a/core/tests/fixtures/recipes/config_from_module_and_recipe/config/config_test.dynamic.dotted.default.yml b/core/tests/fixtures/recipes/config_from_module_and_recipe/config/config_test.dynamic.dotted.default.yml
+new file mode 100644
+index 0000000000..ce5eb672c3
+--- /dev/null
++++ b/core/tests/fixtures/recipes/config_from_module_and_recipe/config/config_test.dynamic.dotted.default.yml
+@@ -0,0 +1,6 @@
++id: dotted.default
++label: 'Provided by recipe'
++weight: 0
++protected_property: Default
++# Intentionally commented out to verify default status behavior.
++# status: 1
+diff --git a/core/tests/fixtures/recipes/config_from_module_and_recipe/config/config_test.system.yml b/core/tests/fixtures/recipes/config_from_module_and_recipe/config/config_test.system.yml
+new file mode 100644
+index 0000000000..5aa1d937ae
+--- /dev/null
++++ b/core/tests/fixtures/recipes/config_from_module_and_recipe/config/config_test.system.yml
+@@ -0,0 +1,2 @@
++foo: bar
++404: foo
+diff --git a/core/tests/fixtures/recipes/config_from_module_and_recipe/recipe.yml b/core/tests/fixtures/recipes/config_from_module_and_recipe/recipe.yml
+new file mode 100644
+index 0000000000..91b42de456
+--- /dev/null
++++ b/core/tests/fixtures/recipes/config_from_module_and_recipe/recipe.yml
+@@ -0,0 +1,12 @@
++name: 'Config from module and recipe'
++type: 'Testing'
++install:
++  - config_test
++  - tour
++  - tour_test
++config:
++  import:
++    config_test: '*'
++    tour_test:
++      - tour.tour.tour-test
++      - tour.tour.tour-test2
+diff --git a/core/tests/fixtures/recipes/config_wildcard/recipe.yml b/core/tests/fixtures/recipes/config_wildcard/recipe.yml
+new file mode 100644
+index 0000000000..582f7aeb89
+--- /dev/null
++++ b/core/tests/fixtures/recipes/config_wildcard/recipe.yml
+@@ -0,0 +1,8 @@
++name: 'Config wildcard'
++type: 'Testing'
++install:
++  - config_test
++  - tour
++config:
++  import:
++    config_test: '*'
+diff --git a/core/tests/fixtures/recipes/install_node_with_config/config/node.settings.yml b/core/tests/fixtures/recipes/install_node_with_config/config/node.settings.yml
+new file mode 100644
+index 0000000000..6cb95cbc42
+--- /dev/null
++++ b/core/tests/fixtures/recipes/install_node_with_config/config/node.settings.yml
+@@ -0,0 +1 @@
++use_admin_theme: true
+diff --git a/core/tests/fixtures/recipes/install_node_with_config/config/node.type.test.yml b/core/tests/fixtures/recipes/install_node_with_config/config/node.type.test.yml
+new file mode 100644
+index 0000000000..567eb1bfe9
+--- /dev/null
++++ b/core/tests/fixtures/recipes/install_node_with_config/config/node.type.test.yml
+@@ -0,0 +1,9 @@
++langcode: en
++status: true
++name: 'Test content type'
++type: test
++description: 'Test content type from a recipe'
++help: ''
++new_revision: true
++preview_mode: 1
++display_submitted: true
+diff --git a/core/tests/fixtures/recipes/install_node_with_config/recipe.yml b/core/tests/fixtures/recipes/install_node_with_config/recipe.yml
+new file mode 100644
+index 0000000000..e2fc243b52
+--- /dev/null
++++ b/core/tests/fixtures/recipes/install_node_with_config/recipe.yml
+@@ -0,0 +1,5 @@
++name: 'Install node with config'
++type: 'Content type'
++install:
++  - node
++  - drupal:text
+diff --git a/core/tests/fixtures/recipes/install_two_modules/recipe.yml b/core/tests/fixtures/recipes/install_two_modules/recipe.yml
+new file mode 100644
+index 0000000000..ee57ca146d
+--- /dev/null
++++ b/core/tests/fixtures/recipes/install_two_modules/recipe.yml
+@@ -0,0 +1,5 @@
++name: 'Install two modules'
++type: 'Content type'
++install:
++  - node
++  - text
+diff --git a/core/tests/fixtures/recipes/missing_extensions/recipe.yml b/core/tests/fixtures/recipes/missing_extensions/recipe.yml
+new file mode 100644
+index 0000000000..77c82fbeee
+--- /dev/null
++++ b/core/tests/fixtures/recipes/missing_extensions/recipe.yml
+@@ -0,0 +1,6 @@
++name: 'Missing extensions'
++type: 'Testing'
++install:
++  - does_not_exist_one
++  - does_not_exist_two
++  - dblog
+diff --git a/core/tests/fixtures/recipes/no_extensions/recipe.yml b/core/tests/fixtures/recipes/no_extensions/recipe.yml
+new file mode 100644
+index 0000000000..b7d3aeb4f0
+--- /dev/null
++++ b/core/tests/fixtures/recipes/no_extensions/recipe.yml
+@@ -0,0 +1,3 @@
++name: 'No extensions'
++description: 'A recipe description'
++type: 'Testing'
+diff --git a/core/tests/fixtures/recipes/no_name/recipe.yml b/core/tests/fixtures/recipes/no_name/recipe.yml
+new file mode 100644
+index 0000000000..65daa60d08
+--- /dev/null
++++ b/core/tests/fixtures/recipes/no_name/recipe.yml
+@@ -0,0 +1 @@
++type: 'Testing'
+diff --git a/core/tests/fixtures/recipes/no_recipe/.gitkeep b/core/tests/fixtures/recipes/no_recipe/.gitkeep
+new file mode 100644
+index 0000000000..e69de29bb2
+diff --git a/core/tests/fixtures/recipes/recipe_include/config/node.type.another_test.yml b/core/tests/fixtures/recipes/recipe_include/config/node.type.another_test.yml
+new file mode 100644
+index 0000000000..48a9258b63
+--- /dev/null
++++ b/core/tests/fixtures/recipes/recipe_include/config/node.type.another_test.yml
+@@ -0,0 +1,9 @@
++langcode: en
++status: true
++name: 'Another test content type'
++type: another_test
++description: 'Another test content type from a recipe'
++help: ''
++new_revision: true
++preview_mode: 1
++display_submitted: true
+diff --git a/core/tests/fixtures/recipes/recipe_include/recipe.yml b/core/tests/fixtures/recipes/recipe_include/recipe.yml
+new file mode 100644
+index 0000000000..a81aa075c0
+--- /dev/null
++++ b/core/tests/fixtures/recipes/recipe_include/recipe.yml
+@@ -0,0 +1,6 @@
++name: 'Recipe include'
++type: 'Testing'
++recipes:
++  - install_node_with_config
++install:
++  - dblog
+diff --git a/core/tests/fixtures/recipes/recipe_include_missing/recipe.yml b/core/tests/fixtures/recipes/recipe_include_missing/recipe.yml
+new file mode 100644
+index 0000000000..b80db734fb
+--- /dev/null
++++ b/core/tests/fixtures/recipes/recipe_include_missing/recipe.yml
+@@ -0,0 +1,7 @@
++name: 'Recipe include'
++type: 'Testing'
++recipes:
++  - recipe_include
++  - does_not_exist
++install:
++  - config_test
+diff --git a/core/tests/fixtures/recipes/theme_with_module_dependencies/recipe.yml b/core/tests/fixtures/recipes/theme_with_module_dependencies/recipe.yml
+new file mode 100644
+index 0000000000..550c3610a9
+--- /dev/null
++++ b/core/tests/fixtures/recipes/theme_with_module_dependencies/recipe.yml
+@@ -0,0 +1,5 @@
++name: 'Theme with module dependencies'
++type: 'Testing'
++install:
++  - test_theme_depending_on_modules
++  - test_module_required_by_theme
+diff --git a/core/tests/fixtures/recipes/unmet_config_dependencies/config/node.type.test.yml b/core/tests/fixtures/recipes/unmet_config_dependencies/config/node.type.test.yml
+new file mode 100644
+index 0000000000..f41e7b3c1b
+--- /dev/null
++++ b/core/tests/fixtures/recipes/unmet_config_dependencies/config/node.type.test.yml
+@@ -0,0 +1,12 @@
++langcode: en
++status: true
++name: 'Test content type'
++type: test
++description: 'Test content type from a recipe'
++help: ''
++new_revision: true
++preview_mode: 1
++display_submitted: true
++dependencies:
++  config:
++    - core.date_format.non_existent
+diff --git a/core/tests/fixtures/recipes/unmet_config_dependencies/recipe.yml b/core/tests/fixtures/recipes/unmet_config_dependencies/recipe.yml
+new file mode 100644
+index 0000000000..e90fca9157
+--- /dev/null
++++ b/core/tests/fixtures/recipes/unmet_config_dependencies/recipe.yml
+@@ -0,0 +1,2 @@
++name: 'Unmet config dependencies'
++type: 'Testing'

--- a/drupal/recipes/wunder_base/recipe.yml
+++ b/drupal/recipes/wunder_base/recipe.yml
@@ -45,6 +45,7 @@ config:
     claro: '*'
     webform: '*'
     webform_ui: '*'
+    editor: '*'
   actions:
     system.theme:
       simple_config_update:

--- a/next/components/media/media--document.tsx
+++ b/next/components/media/media--document.tsx
@@ -1,6 +1,5 @@
 import { useTranslation } from "next-i18next";
 
-import { absoluteUrl } from "@/lib/drupal/absolute-url";
 import type { FragmentMediaDocumentFragment } from "@/lib/gql/graphql";
 import { formatFileSizeInBytes } from "@/lib/utils";
 import ListIcon from "@/styles/icons/list.svg";
@@ -55,7 +54,7 @@ export function MediaDocument({
 
   return (
     <a
-      href={absoluteUrl(media.mediaDocumentFile.url)}
+      href={media.mediaDocumentFile.url}
       className="flex items-center"
       download
     >

--- a/next/lib/drupal/absolute-url.ts
+++ b/next/lib/drupal/absolute-url.ts
@@ -1,5 +1,0 @@
-import { env } from "@/env";
-
-export function absoluteUrl(input: string) {
-  return `${env.NEXT_PUBLIC_DRUPAL_BASE_URL}${input}`;
-}

--- a/next/pages/[...slug].tsx
+++ b/next/pages/[...slug].tsx
@@ -66,6 +66,8 @@ export const getStaticPaths: GetStaticPaths = async (context) => {
     // Build static paths for the current locale.
     const localePaths = drupal.buildStaticPathsParamsFromPaths(pathArray, {
       locale,
+      // Because graphql returns the path with the language prefix, we strip it using the pathPrefix option:
+      pathPrefix: `/${locale}`,
     });
 
     // Add the paths to the static paths array:

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -21,6 +21,7 @@ php:
   postupgrade:
     afterCommand: |
       drush si minimal --account-pass=${DRUPAL_ADMIN_PWD} -y
+      drush st
       chmod +x /app/web/core/scripts/drupal
       cd /app/web && core/scripts/drupal recipe ../recipes/wunder_next_setup
       drush cr

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -21,9 +21,9 @@ php:
   postupgrade:
     afterCommand: |
       drush si minimal --account-pass=${DRUPAL_ADMIN_PWD} -y
-      drush st
+      drush cr
       chmod +x /app/web/core/scripts/drupal
-      cd /app/web && core/scripts/drupal recipe ../recipes/wunder_next_setup
+      cd /app/web && php core/scripts/drupal recipe ../recipes/wunder_next_setup
       drush cr
       drush wunder_next:setup-user-and-consumer
       drush en wunder_democontent -y

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -23,7 +23,7 @@ php:
       drush si minimal --account-pass=${DRUPAL_ADMIN_PWD} -y
       drush cr
       chmod +x /app/web/core/scripts/drupal
-      cd /app/web && php core/scripts/drupal recipe ../recipes/wunder_next_setup
+      cd /app/web && php core/scripts/drupal recipe ../recipes/wunder_next_setup -vvv
       drush cr
       drush wunder_next:setup-user-and-consumer
       drush en wunder_democontent -y


### PR DESCRIPTION
This branch adds updates and fixes for core and contrib

1. fix security issue with registration_role https://www.drupal.org/sa-contrib-2024-015 
2. update to drupal 10.2.4 and drush 12. For this we also needed to update the recipes patch
3. add patch for paragraphs 1.17 when used with 10.2.4 https://www.drupal.org/node/3425348
4. turn the 10.2 core patch for recipes into a local patch
5. fix issue with links in media component
6. fix getStaticPaths (paths had double language)
