### PR TITLE
Improve service used to export the sitemap to a file

### DIFF
--- a/drupal/web/modules/custom/wunder_sitemap/src/SitemapExporter.php
+++ b/drupal/web/modules/custom/wunder_sitemap/src/SitemapExporter.php
@@ -5,7 +5,6 @@ namespace Drupal\wunder_sitemap;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
-use Drupal\file\FileRepository;
 use Drupal\file\FileRepositoryInterface;
 use Drupal\file\FileUsage\DatabaseFileUsageBackend;
 use Drupal\simple_sitemap\Manager\Generator;
@@ -30,14 +29,14 @@ class SitemapExporter {
   protected Generator $simpleSitemapGenerator;
 
   /**
-   * Drupal\Core\File\FileSystem definition.
+   * Drupal\file\FileRepositoryInterface definition.
    *
    * @var \Drupal\file\FileRepositoryInterface
    */
-  protected FileRepository $fileRepository;
+  protected FileRepositoryInterface $fileRepository;
 
   /**
-   * Drupal\Core\File\FileSystem definition.
+   * Drupal\file\FileUsage\DatabaseFileUsageBackend definition.
    *
    * @var \Drupal\file\FileUsage\DatabaseFileUsageBackend
    */

--- a/drupal/web/modules/custom/wunder_sitemap/wunder_sitemap.info.yml
+++ b/drupal/web/modules/custom/wunder_sitemap/wunder_sitemap.info.yml
@@ -5,3 +5,4 @@ package: Trimble
 core_version_requirement: ^9 || ^10
 dependencies:
   - simple_sitemap:simple_sitemap
+  - drupal:file

--- a/drupal/web/modules/custom/wunder_sitemap/wunder_sitemap.services.yml
+++ b/drupal/web/modules/custom/wunder_sitemap/wunder_sitemap.services.yml
@@ -4,4 +4,4 @@ services:
     arguments: ['wunder_sitemap']
   wunder_sitemap.exporter:
     class: Drupal\wunder_sitemap\SitemapExporter
-    arguments: ['@logger.channel.wunder_sitemap', '@simple_sitemap.generator', '@file_system']
+    arguments: ['@logger.channel.wunder_sitemap', '@simple_sitemap.generator', '@file.repository', '@file.usage']

--- a/next/next.config.js
+++ b/next/next.config.js
@@ -18,7 +18,7 @@ const nextConfig = {
       beforeFiles: [
         {
           source: "/sitemap.xml",
-          destination: `${process.env.NEXT_PUBLIC_DRUPAL_BASE_URL}/sites/default/files/sitemap.xml`,
+          destination: `https://${process.env.NEXT_IMAGE_DOMAIN}/sites/default/files/sitemap.xml`,
         },
       ],
     };

--- a/next/next.config.js
+++ b/next/next.config.js
@@ -18,7 +18,7 @@ const nextConfig = {
       beforeFiles: [
         {
           source: "/sitemap.xml",
-          destination: `https://${process.env.NEXT_IMAGE_DOMAIN}/sites/default/files/sitemap.xml`,
+          destination: `${process.env.NEXT_PUBLIC_DRUPAL_BASE_URL}/sites/default/files/sitemap.xml`,
         },
       ],
     };

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -30,6 +30,7 @@ php:
       drush eshd -y
       drush eshs
       drush mim --group=demo_content --execute-dependencies --skip-progress-bar
+      drush cron
 
 # Configure reference data that will be used when creating new environments.
 referenceData:


### PR DESCRIPTION
In order to serve the sitemap at [frontend]/sitemap.xml , we: 

1. export the sitemap to a file in `public//siltemap.xml`
2. add a rewrite to next.js proxying /sitemap.xml to [drupal]/site/default/files/sitemap.xml

The current code in `wunder_sitemap` can result in the sitemap.xml file that gets exported to be deleted, since it's not registered as a drupal file.

With the changes in this PR:
* now the file will be an actual file entity with a usage, and so it won't be removed by cron.
* the file won't be replaced if the sitemap is empty



With this change, once you run cron, you should see this entry in the list of files:

![image](https://github.com/wunderio/next-drupal-starterkit/assets/185412/2ba1954d-5bd4-400c-b243-7b6b93cdd8b6)
