### PR TITLE
NEX-143: Retry functionality (revisited)

### DIFF
--- a/next/lib/drupal/drupal-client.ts
+++ b/next/lib/drupal/drupal-client.ts
@@ -1,8 +1,31 @@
+import pRetry from "p-retry";
+
 import { GraphQlDrupalClient } from "./graphql-drupal-client";
 
 import { env } from "@/env";
 
+const getFetcher =
+  () =>
+  async (input: RequestInfo, init: RequestInit = {}) => {
+    const wrappedFetch = async () => {
+      return await fetch(input, {
+        ...init,
+      });
+    };
+    // Return the pRetry wrapped fetch function:
+    return pRetry(wrappedFetch, {
+      retries: 5,
+      onFailedAttempt: (error) => {
+        console.log(
+          `Drupal fetch: attempt ${error.attemptNumber} failed. There are ${error.retriesLeft} retries left.`,
+        );
+      },
+    });
+  };
+
 export const drupal = new GraphQlDrupalClient(env.NEXT_PUBLIC_DRUPAL_BASE_URL, {
+  // We specify our own fetcher to apply pRetry to it:
+  fetcher: getFetcher(),
   forceIframeSameSiteCookie: env.NODE_ENV === "development",
   auth: {
     clientId: env.DRUPAL_CLIENT_ID,

--- a/next/lib/drupal/get-articles.ts
+++ b/next/lib/drupal/get-articles.ts
@@ -1,5 +1,3 @@
-import pRetry from "p-retry";
-
 import { drupal } from "@/lib/drupal/drupal-client";
 import type { ArticleTeaserType } from "@/types/graphql";
 
@@ -24,16 +22,12 @@ export const getArticles = async ({
   let nodes: ArticleTeaserType[] = [];
   let totalPages = 1;
   try {
-    const articlesViewResult = await pRetry(
-      () =>
-        drupal.doGraphQlRequest(LISTING_ARTICLES, {
-          langcode: locale,
-          page: 0,
-          pageSize: limit,
-          offset: offset,
-        }),
-      { retries: 5 },
-    );
+    const articlesViewResult = await drupal.doGraphQlRequest(LISTING_ARTICLES, {
+      langcode: locale,
+      page: 0,
+      pageSize: limit,
+      offset: offset,
+    });
 
     if (articlesViewResult.articlesView?.results) {
       nodes = articlesViewResult.articlesView.results as ArticleTeaserType[];

--- a/next/lib/drupal/get-menus.ts
+++ b/next/lib/drupal/get-menus.ts
@@ -1,5 +1,4 @@
 import { GetStaticPropsContext } from "next";
-import pRetry from "p-retry";
 
 import { drupal } from "@/lib/drupal/drupal-client";
 
@@ -9,14 +8,10 @@ import { GET_MENU } from "../graphql/queries";
 export async function getMenus({ locale }: GetStaticPropsContext) {
   const [main, footer] = await Promise.all(
     ["MAIN", "FOOTER"].map((menu) =>
-      pRetry(
-        () =>
-          drupal.doGraphQlRequest(GET_MENU, {
-            name: menu as MenuAvailable,
-            langcode: locale,
-          }),
-        { retries: 5 },
-      ),
+      drupal.doGraphQlRequest(GET_MENU, {
+        name: menu as MenuAvailable,
+        langcode: locale,
+      }),
     ),
   );
 

--- a/next/lib/drupal/get-node-translated-versions.ts
+++ b/next/lib/drupal/get-node-translated-versions.ts
@@ -1,5 +1,4 @@
 import { GetStaticPropsContext } from "next";
-import pRetry from "p-retry";
 
 import { Translations } from "@/lib/contexts/language-links-context";
 import { GET_NODE_PATH_BY_ID_AND_LANGCODE } from "@/lib/graphql/queries";
@@ -36,10 +35,9 @@ export const getNodeTranslatedVersions = async (
         langcode: locales[i],
       };
 
-      const translatedNodeResult = await pRetry(
-        () =>
-          drupal.doGraphQlRequest(GET_NODE_PATH_BY_ID_AND_LANGCODE, variables),
-        { retries: 5 },
+      const translatedNodeResult = await drupal.doGraphQlRequest(
+        GET_NODE_PATH_BY_ID_AND_LANGCODE,
+        variables,
       );
 
       if (

--- a/next/pages/[...slug].tsx
+++ b/next/pages/[...slug].tsx
@@ -1,6 +1,5 @@
 import type { PreviewData } from "next";
 import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from "next";
-import pRetry from "p-retry";
 
 import { Meta } from "@/components/meta";
 import { Node } from "@/components/node";
@@ -52,15 +51,11 @@ export const getStaticPaths: GetStaticPaths = async (context) => {
 
   for (const locale of locales) {
     // Get the defined paths via graphql for the current locale:
-    const data = await pRetry(
-      () =>
-        drupal.doGraphQlRequest(GET_STATIC_PATHS, {
-          // We will query for the latest 10 items of each content type:
-          number: 10,
-          langcode: locale,
-        }),
-      { retries: 5 },
-    );
+    const data = await drupal.doGraphQlRequest(GET_STATIC_PATHS, {
+      // We will query for the latest 10 items of each content type:
+      number: 10,
+      langcode: locale,
+    });
 
     // Get all paths from the response:
     const pathArray = [
@@ -105,15 +100,11 @@ export const getStaticProps: GetStaticProps<PageProps> = async (context) => {
   const isPreview = context.preview || false;
 
   // Get the page data with Graphql:
-  const data = await pRetry(
-    () =>
-      drupal.doGraphQlRequest(
-        GET_ENTITY_AT_DRUPAL_PATH,
-        variables,
-        // We want to use authentication only if this is a preview request:
-        isPreview ? true : false,
-      ),
-    { retries: 5 },
+  const data = await drupal.doGraphQlRequest(
+    GET_ENTITY_AT_DRUPAL_PATH,
+    variables,
+    // We want to use authentication only if this is a preview request:
+    isPreview ? true : false,
   );
 
   // If the data contains a RedirectResponse, we redirect to the path:
@@ -161,15 +152,11 @@ export const getStaticProps: GetStaticProps<PageProps> = async (context) => {
     const revisionPath = `/node/${nodeId}/revisions/${revisionId}/view`;
 
     // Get the node at the specific data with Graphql:
-    const revisionRoutedata = await pRetry(
-      () =>
-        drupal.doGraphQlRequest(
-          GET_ENTITY_AT_DRUPAL_PATH,
-          { path: revisionPath, langcode: context.locale },
-          // We need to do an authenticated request to get the revision:
-          true,
-        ),
-      { retries: 5 },
+    const revisionRoutedata = await drupal.doGraphQlRequest(
+      GET_ENTITY_AT_DRUPAL_PATH,
+      { path: revisionPath, langcode: context.locale },
+      // We need to do an authenticated request to get the revision:
+      true,
     );
 
     // Instead of the entity at the current revision, we want now to

--- a/next/pages/api/articles-listing/[lang].ts
+++ b/next/pages/api/articles-listing/[lang].ts
@@ -1,5 +1,4 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import pRetry from "p-retry";
 
 import { drupal } from "@/lib/drupal/drupal-client";
 import { LISTING_ARTICLES } from "@/lib/graphql/queries";
@@ -16,14 +15,13 @@ export default async function handler(
 
     const limit = Number(req.query.limit) || 10;
 
-    const articlesQueryResult = await pRetry(
-      () =>
-        drupal.doGraphQlRequest(LISTING_ARTICLES, {
-          langcode: languagePrefix,
-          page: 0,
-          pageSize: limit,
-        }),
-      { retries: 5 },
+    const articlesQueryResult = await drupal.doGraphQlRequest(
+      LISTING_ARTICLES,
+      {
+        langcode: languagePrefix,
+        page: 0,
+        pageSize: limit,
+      },
     );
 
     // Set cache headers: 60 seconds max-age, stale-while-revalidate

--- a/next/pages/api/auth/[...nextauth].ts
+++ b/next/pages/api/auth/[...nextauth].ts
@@ -3,6 +3,8 @@ import NextAuth from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
 import { jwtDecode } from "jwt-decode";
 
+import { drupal } from "@/lib/drupal/drupal-client";
+
 import { env } from "@/env";
 
 export const authOptions: NextAuthOptions = {
@@ -32,7 +34,7 @@ export const authOptions: NextAuthOptions = {
         formData.append("password", credentials.password);
 
         // Get access token from Drupal.
-        const response = await fetch(
+        const response = await drupal.fetch(
           `${env.NEXT_PUBLIC_DRUPAL_BASE_URL}/oauth/token`,
           {
             method: "POST",

--- a/next/pages/api/contact.ts
+++ b/next/pages/api/contact.ts
@@ -1,6 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth/next";
-import pRetry from "p-retry";
 
 import { drupal } from "@/lib/drupal/drupal-client";
 import { authOptions } from "@/pages/api/auth/[...nextauth]";
@@ -26,25 +25,21 @@ export default async function handler(
       const body = JSON.parse(req.body);
 
       // Submit to Drupal.
-      const result = await pRetry(
-        () =>
-          drupal.fetch(url.toString(), {
-            method: "POST",
-            body: JSON.stringify({
-              webform_id: "contact",
-              name: body.name,
-              email: body.email,
-              message: body.message,
-              subject: body.subject,
-            }),
-            headers: {
-              "Content-Type": "application/json",
-              // Pass the token to authenticate the request:
-              Authorization: `Bearer ${session.accessToken}`, // eslint-disable-line @typescript-eslint/no-base-to-string
-            },
-          }),
-        { retries: 5 },
-      );
+      const result = await drupal.fetch(url.toString(), {
+        method: "POST",
+        body: JSON.stringify({
+          webform_id: "contact",
+          name: body.name,
+          email: body.email,
+          message: body.message,
+          subject: body.subject,
+        }),
+        headers: {
+          "Content-Type": "application/json",
+          // Pass the token to authenticate the request:
+          Authorization: `Bearer ${session.accessToken}`, // eslint-disable-line @typescript-eslint/no-base-to-string
+        },
+      });
 
       if (result.ok) {
         res.status(200).end();

--- a/next/pages/api/search.ts
+++ b/next/pages/api/search.ts
@@ -1,5 +1,4 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import pRetry from "p-retry";
 
 import { env } from "@/env";
 
@@ -14,15 +13,11 @@ const Search = async (req: NextApiRequest, res: NextApiResponse) => {
   const ProxyUrl = `${env.NEXT_PUBLIC_DRUPAL_BASE_URL}/${languagePrefix}/wunder_search/proxy`;
 
   try {
-    const result = await pRetry(
-      () =>
-        fetch(ProxyUrl, {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify(req.body),
-        }),
-      { retries: 5 },
-    );
+    const result = await fetch(ProxyUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(req.body),
+    });
 
     if (!result.ok) {
       res.status(result.status).json({ error: result.statusText });

--- a/next/pages/api/search.ts
+++ b/next/pages/api/search.ts
@@ -1,7 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { env } from "@/env";
+import { drupal } from "@/lib/drupal/drupal-client";
 
+import { env } from "@/env";
 /**
  * Example backend proxy for Elasticsearch Search-UI frontend client.
  */
@@ -13,7 +14,7 @@ const Search = async (req: NextApiRequest, res: NextApiResponse) => {
   const ProxyUrl = `${env.NEXT_PUBLIC_DRUPAL_BASE_URL}/${languagePrefix}/wunder_search/proxy`;
 
   try {
-    const result = await fetch(ProxyUrl, {
+    const result = await drupal.fetch(ProxyUrl, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(req.body),

--- a/next/pages/dashboard/index.tsx
+++ b/next/pages/dashboard/index.tsx
@@ -4,7 +4,6 @@ import { useRouter } from "next/router";
 import { getServerSession } from "next-auth/next";
 import { useSession } from "next-auth/react";
 import { useTranslation } from "next-i18next";
-import pRetry from "p-retry";
 
 import { HeadingPage } from "@/components/heading--page";
 import { Meta } from "@/components/meta";
@@ -94,18 +93,14 @@ export const getServerSideProps: GetServerSideProps<
     `/${locale}/rest/my-webform-submissions?_format=json`,
   );
 
-  const result = await pRetry(
-    () =>
-      drupal.fetch(url.toString(), {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          // Pass the token to authenticate the request:
-          Authorization: `Bearer ${session.accessToken}`, // eslint-disable-line @typescript-eslint/no-base-to-string
-        },
-      }),
-    { retries: 5 },
-  );
+  const result = await drupal.fetch(url.toString(), {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      // Pass the token to authenticate the request:
+      Authorization: `Bearer ${session.accessToken}`, // eslint-disable-line @typescript-eslint/no-base-to-string
+    },
+  });
 
   const submissionsViewResult = (await result.json()) as
     | WebformSubmissionsListEmpty

--- a/next/pages/dashboard/webforms/[webformName]/[webformSubmissionUuid].tsx
+++ b/next/pages/dashboard/webforms/[webformName]/[webformSubmissionUuid].tsx
@@ -2,7 +2,6 @@ import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { getServerSession } from "next-auth/next";
 import { useTranslation } from "next-i18next";
-import pRetry from "p-retry";
 
 import { HeadingPage } from "@/components/heading--page";
 import { Meta } from "@/components/meta";
@@ -70,18 +69,14 @@ export const getServerSideProps: GetServerSideProps<
     `/${locale}/webform_rest/${params.webformName}/complete_submission/${params.webformSubmissionUuid}`,
   );
 
-  const result = await pRetry(
-    () =>
-      drupal.fetch(url.toString(), {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          // Pass the token to authenticate the request:
-          Authorization: `Bearer ${session.accessToken}`, // eslint-disable-line @typescript-eslint/no-base-to-string
-        },
-      }),
-    { retries: 5 },
-  );
+  const result = await drupal.fetch(url.toString(), {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      // Pass the token to authenticate the request:
+      Authorization: `Bearer ${session.accessToken}`, // eslint-disable-line @typescript-eslint/no-base-to-string
+    },
+  });
 
   if (!result.ok) {
     return {

--- a/next/pages/index.tsx
+++ b/next/pages/index.tsx
@@ -1,6 +1,5 @@
 import { GetStaticProps, InferGetStaticPropsType } from "next";
 import { useTranslation } from "next-i18next";
-import pRetry from "p-retry";
 
 import { ArticleTeasers } from "@/components/article/article-teasers";
 import { ContactList } from "@/components/contact-list";
@@ -61,9 +60,9 @@ export const getStaticProps: GetStaticProps<HomepageProps> = async (
     langcode: context.locale,
   };
 
-  const data = await pRetry(
-    () => drupal.doGraphQlRequest(GET_ENTITY_AT_DRUPAL_PATH, variables),
-    { retries: 5 },
+  const data = await drupal.doGraphQlRequest(
+    GET_ENTITY_AT_DRUPAL_PATH,
+    variables,
   );
 
   const frontpage = extractEntityFromRouteQueryResult(data);
@@ -84,16 +83,12 @@ export const getStaticProps: GetStaticProps<HomepageProps> = async (
   }
 
   // Get the last 3 sticky articles in the current language:
-  const stickyArticleTeasers = await pRetry(
-    () =>
-      drupal.doGraphQlRequest(LISTING_ARTICLES, {
-        langcode: context.locale,
-        sticky: true,
-        page: 0,
-        pageSize: 3,
-      }),
-    { retries: 5 },
-  );
+  const stickyArticleTeasers = await drupal.doGraphQlRequest(LISTING_ARTICLES, {
+    langcode: context.locale,
+    sticky: true,
+    page: 0,
+    pageSize: 3,
+  });
 
   // We cast the results as the ListingArticle type to get type safety:
   const articles =


### PR DESCRIPTION
in a previous PR ( #192 ), we added p-retry to allow the frontend to recover if drupal is not available momentarily.

But, we did it by wrapping each call to Drupal.fetch or drupal.doGrapqhlrequest in p-retry, which is a bit cumbersome and also means that future developers need to remember to add it everywhere.

In this revisited PR instead we do it at the drupal.client level (and in our added method to do graphql requests).

Also, we make sure that we don't use fetch by itself (we had a couple of API calls that did it) , but always drupal.fetch to get this added functionality.

Here's a short demo video: 

https://github.com/wunderio/next-drupal-starterkit/assets/185412/e3360054-582d-4923-853f-581fae98639f


