### PR TITLE
NEX-144: Switch to standalone next build in CI, adapt the dockerfile

### DIFF
--- a/next/next.config.js
+++ b/next/next.config.js
@@ -3,6 +3,8 @@ const { i18n } = require("./next-i18next.config");
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  // Only generate standalone output in circle ci:
+  output: process.env.CI ? "standalone" : undefined,
   images: {
     remotePatterns: [
       {

--- a/silta/node.Dockerfile
+++ b/silta/node.Dockerfile
@@ -10,5 +10,5 @@ WORKDIR /app
 
 ENV PORT 3000
 
-# In standalone mode, we cannot use npm run start, we have to use the server.js file
+# server.js is created by next build from the standalone output
 CMD ["node", "server.js"]

--- a/silta/node.Dockerfile
+++ b/silta/node.Dockerfile
@@ -1,5 +1,10 @@
 FROM wunderio/silta-node:20-alpine-v1
 
+# Note: this dockerfile is meant to be used in combination with Silta and CircleCI.
+# Because the build happens in CircleCI, we don't need to build the app in the dockerfile itself.
+# For a more generic solution, you can check next.js's official docker example here:
+# https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile
+
 # Because we are using the standalone mode, we copy only the needed files
 # to the image.
 COPY ./.next/standalone /app
@@ -10,5 +15,5 @@ WORKDIR /app
 
 ENV PORT 3000
 
-# server.js is created by next build from the standalone output
+# server.js is created by next build from the standalone output:
 CMD ["node", "server.js"]

--- a/silta/node.Dockerfile
+++ b/silta/node.Dockerfile
@@ -1,8 +1,14 @@
 FROM wunderio/silta-node:20-alpine-v1
 
+# Because we are using the standalone mode, we copy only the needed files
+# to the image.
 COPY ./.next/standalone /app
 COPY ./.next/static /app/.next/static
 COPY ./public /app/public
 
+WORKDIR /app
 
+ENV PORT 3000
+
+# In standalone mode, we cannot use npm run start, we have to use the server.js file
 CMD ["node", "server.js"]

--- a/silta/node.Dockerfile
+++ b/silta/node.Dockerfile
@@ -1,5 +1,8 @@
 FROM wunderio/silta-node:20-alpine-v1
 
-COPY . /app
+COPY ./.next/standalone /app
+COPY ./.next/static /app/.next/static
+COPY ./public /app/public
 
-CMD npm run start
+
+CMD ["node", "server.js"]


### PR DESCRIPTION
In this PR: 

* set the  [standalone option](https://nextjs.org/docs/pages/api-reference/next-config-js/output#automatically-copying-traced-files) for `npm run build` when in CI
* adapt the dockerfile to copy the needed directories in the right place, and switch to the minimal `server.js` script to run the site 


This gives us: 
1. smaller docker image size
2. quicker build ( before: 1m 35s, after: 32s)

should be greener!


### To test: 

1. on silta the site should still work: https://standalone-next.next-drupal-starterkit.dev.wdr.io
2. locally, nothing should change, you can still use `npm run build` and then `npm run start`

