### PR TITLE
NEX-147: Do not revalidate in silta when building the template

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -198,8 +198,6 @@ services:
 proxy:
   mailhog:
     - mail.lndo.site
-  elasticsearch:
-    - elasticsearch.lndo.site:9200
   kibana:
     - kibana.lndo.site:5601
   node:

--- a/drupal/web/modules/custom/wunder_democontent/src/EventSubscriber/WunderDemocontentRevalidateSubscriber.php
+++ b/drupal/web/modules/custom/wunder_democontent/src/EventSubscriber/WunderDemocontentRevalidateSubscriber.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\wunder_democontent\EventSubscriber;
+
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\next\Event\EntityActionEvent;
+use Drupal\next\Event\EntityEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Prevents revalidation when a state var is set.
+ */
+final class WunderDemocontentRevalidateSubscriber implements EventSubscriberInterface {
+
+  const DISABLE_REVALIDATION_STATE_VARIABLE = 'wunder_democontent.disable_revalidation';
+
+  /**
+   * Constructs a WunderDemocontentSubscriber object.
+   */
+  public function __construct(
+    private readonly LoggerChannelInterface $loggerChannelWunderDemocontent,
+    private readonly StateInterface $state,
+  ) {
+  }
+
+  /**
+   * Revalidates the entity.
+   *
+   * @param \Drupal\next\Event\EntityActionEvent $event
+   *   The event.
+   */
+  public function onAction(EntityActionEvent $event) {
+    // When this module is active, and the state variable is set to true,
+    // We stop propagation of the revalidation events and we log a message.
+    if ($this->state->get(self::DISABLE_REVALIDATION_STATE_VARIABLE, FALSE) === TRUE) {
+      $this->loggerChannelWunderDemocontent->info("Stopping revalidation of @type entity @label (@id), because the @state state variable is set to true.", [
+        '@id' => $event->getEntity()->id(),
+        '@type' => $event->getEntity()->getEntityTypeId(),
+        '@label' => $event->getEntity()->label(),
+        '@state' => self::DISABLE_REVALIDATION_STATE_VARIABLE,
+      ]);
+      $event->stopPropagation();
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    // This is higher than the priority that the next module has
+    // so that this event will be executed first:
+    $events[EntityEvents::ENTITY_ACTION] = ['onAction', 100];
+    return $events;
+  }
+
+}

--- a/drupal/web/modules/custom/wunder_democontent/wunder_democontent.services.yml
+++ b/drupal/web/modules/custom/wunder_democontent/wunder_democontent.services.yml
@@ -1,0 +1,10 @@
+services:
+  wunder_democontent.event_subscriber:
+    class: Drupal\wunder_democontent\EventSubscriber\WunderDemocontentRevalidateSubscriber
+    arguments: ['@logger.channel.wunder_democontent', '@state']
+    tags:
+      - { name: event_subscriber }
+  logger.channel.wunder_democontent:
+    class: Drupal\Core\Logger\LoggerChannel
+    factory: logger.factory:get
+    arguments: ['wunder_democontent']

--- a/next/next.config.js
+++ b/next/next.config.js
@@ -4,7 +4,7 @@ const { i18n } = require("./next-i18next.config");
 const nextConfig = {
   reactStrictMode: true,
   // Only generate standalone output in circle ci:
-  output: process.env.CI ? "standalone" : undefined,
+  output: process.env.CIRCLECI ? "standalone" : undefined,
   images: {
     remotePatterns: [
       {

--- a/setup.sh
+++ b/setup.sh
@@ -15,6 +15,7 @@ commands=(
   "(lando npm run start&)"
   "lando drush en wunder_democontent -y"
   "lando drush mim --group=demo_content --execute-dependencies"
+  "lando drush pm-uninstall wunder_democontent migrate migrate_tools migrate_plus -y"
   "lando npm-stop || true"
 )
 

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -26,10 +26,12 @@ php:
       cd /app/web && php core/scripts/drupal recipe ../recipes/wunder_next_setup -vvv
       drush cr
       drush wunder_next:setup-user-and-consumer
+      drush state:set wunder_democontent.disable_revalidation TRUE
       drush en wunder_democontent -y
       drush eshd -y
       drush eshs
       drush mim --group=demo_content --execute-dependencies --skip-progress-bar
+      drush state:del wunder_democontent.disable_revalidation
       drush cron
 
 # Configure reference data that will be used when creating new environments.


### PR DESCRIPTION
Now that we added #193 , our build in silta for the main environment started failing.

The reason is that we run the migration included in `wunder_democontent` after deployment, which in turn tries to call the frontend for revalidation. This won't work, because the frontend will either not exist or have a different secret

So this pr adds a mechanism to prevent revalidation while the migration runs.

This is done with an event subscriber set to a higher priority than what the `next` module provides, which will stop the propagation of the event if a state variable is set. We set that variable during the build in silta, then we unset it.


Also, I added a couple of other small things: 

1. I removed the proxy elasticsearch in lando (gave an error, does not really do much)
2. we were checking for the env var `CI` when deciding whether to build in standalone mode, but apparently inside lando it's set to 1 as well, so we are switching for the more specific `CIRCLECI` which we can be sure is there in circle ci (https://circleci.com/docs/variables/#built-in-environment-variables)




After deployment, these logs are visible: 

![image](https://github.com/wunderio/next-drupal-starterkit/assets/185412/6fbbb7b5-1480-4a2a-8650-874d847df87a)


Also in circle ci we can see no more guzzle errors.
