### PR TITLE
If a catch-all route loads a frontpage node, redirect to / in the correct locale

### DIFF
--- a/next/pages/[...slug].tsx
+++ b/next/pages/[...slug].tsx
@@ -1,4 +1,4 @@
-import type { PreviewData } from "next";
+import type { PreviewData, Redirect } from "next";
 import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from "next";
 
 import { Meta } from "@/components/meta";
@@ -121,11 +121,22 @@ export const getStaticProps: GetStaticProps<PageProps> = async (context) => {
 
   // Get the entity from the response:
   let nodeEntity = extractEntityFromRouteQueryResult(data);
+
   // If there's no node, return 404:
   if (!nodeEntity) {
     return {
       notFound: true,
       revalidate: 60,
+    };
+  }
+
+  // If node is a frontpage, redirect to / for the current locale:
+  if (nodeEntity.__typename === "NodeFrontpage") {
+    return {
+      redirect: {
+        destination: `/${context.locale}`,
+        permanent: false,
+      } satisfies Redirect,
     };
   }
 


### PR DESCRIPTION
## Link to feature environment:

https://feature-frontpage-redirect-051.next-drupal-starterkit.dev.wdr.io/

## Changes proposed in this PR:

- If a user visits e.g. /fi/frontpage-fi, redirect to /fi instead of showing duplicate content under the /frontpage-fi url

## How to test:

Compare the behaviour of affected urls between main environment and this one, e.g.:
- https://next-drupal-starterkit.dev.wdr.io/frontpage-en to https://feature-frontpage-redirect-051.next-drupal-starterkit.dev.wdr.io/frontpage-en
- https://next-drupal-starterkit.dev.wdr.io/fi/frontpage-fi to https://feature-frontpage-redirect-051.next-drupal-starterkit.dev.wdr.io/fi/frontpage-fi

