### PR TITLE
Support rendering nodes that are not set up to be translatable

### DIFF
--- a/next/lib/contexts/language-links-context.tsx
+++ b/next/lib/contexts/language-links-context.tsx
@@ -13,14 +13,20 @@ const LanguageLinksContext = createContext(siteConfig.locales);
  * From the site config and available node translations, create links to be used in the language switcher.
  */
 export function createLanguageLinks(
-  nodeTranslations?: FragmentNodeTranslationFragment[],
+  nodeTranslations: FragmentNodeTranslationFragment[],
 ): LanguageLinks {
-  const languageLinks = JSON.parse(JSON.stringify(siteConfig.locales));
+  const languageLinks = getStandardLanguageLinks();
   Object.values(nodeTranslations).forEach(({ langcode, path }) => {
     languageLinks[langcode.id].path = path;
   });
   return languageLinks;
 }
+
+/**
+ * Get the standard language links from the site config.
+ */
+export const getStandardLanguageLinks = () =>
+  JSON.parse(JSON.stringify(siteConfig.locales));
 
 /**
  * Generates a language links object for a page that is created in next only.
@@ -33,7 +39,7 @@ export function createLanguageLinksForNextOnlyPage(
   path: string,
   context: GetStaticPropsContext,
 ): LanguageLinks {
-  const languageLinks = JSON.parse(JSON.stringify(siteConfig.locales));
+  const languageLinks = getStandardLanguageLinks();
   context.locales.forEach((locale) => {
     languageLinks[locale].path =
       languageLinks[locale].path === "/"

--- a/next/pages/[...slug].tsx
+++ b/next/pages/[...slug].tsx
@@ -7,6 +7,7 @@ import {
   createLanguageLinks,
   LanguageLinks,
 } from "@/lib/contexts/language-links-context";
+import { getStandardLanguageLinks } from "@/lib/contexts/language-links-context";
 import { drupal } from "@/lib/drupal/drupal-client";
 import {
   CommonPageProps,
@@ -189,7 +190,14 @@ export const getStaticProps: GetStaticProps<PageProps> = async (context) => {
   }
 
   // Add information about possible other language versions of this node.
-  const languageLinks = createLanguageLinks(nodeEntity.translations);
+  let languageLinks;
+  // Not all node types necessarily have translations enabled,
+  // if so, only show the standard language links.
+  if ("translations" in nodeEntity) {
+    languageLinks = createLanguageLinks(nodeEntity.translations);
+  } else {
+    languageLinks = getStandardLanguageLinks();
+  }
 
   return {
     props: {


### PR DESCRIPTION
Currently the recent changes in #205 assume that all node types are set up for translations.


This might not be the case, and currently the site will break, expecting all content types to have a `translations` property. this PR fixes that, allowing the node not to have that property and still be rendered.

The language links will just be the standard ones. 