### PR TITLE
NEX-152: Return permanent or temporary redirect based on the redirect status code set on the Drupal side

### DIFF
--- a/next/pages/[...slug].tsx
+++ b/next/pages/[...slug].tsx
@@ -114,7 +114,9 @@ export const getStaticProps: GetStaticProps<PageProps> = async (context) => {
     return {
       redirect: {
         destination: redirect.url,
-        permanent: false,
+        // Set to temporary redirect for 302 and 307 status codes,
+        // and permanent for all others.
+        permanent: !(redirect.status === 307 || redirect.status === 302),
       },
     };
   }


### PR DESCRIPTION
## Link to ticket:

https://wunder.atlassian.net/browse/NEX-145

## Changes proposed in this PR:

We have setup the [..slug].tsx page to handle redirects: if the route corresponds to a redirect we do a redirect in next.js

However, so far we were always returning a temporary redirect (which for next.js means `307` response status). In drupal you are able to set the response code (the most common being 301). 

So in this PR we map status codes in Drupal to response codes in next.js like this: 

`302`, `307` -> `permanent: false`
all others -> `permanent: true`


![image](https://github.com/wunderio/next-drupal-starterkit/assets/185412/c8178e06-2e94-49b1-b475-807e5c836e0b)

