### PR TITLE
NEX-153: Remove withAuth option from Drupal client's doGraphQlRequest

### DIFF
--- a/next/lib/drupal/graphql-drupal-client.ts
+++ b/next/lib/drupal/graphql-drupal-client.ts
@@ -9,18 +9,14 @@ export class GraphQlDrupalClient extends DrupalClient {
   async doGraphQlRequest<T>(
     query: TypedDocumentNode<T> | RequestDocument,
     variables?: Variables,
-    withAuth = true,
   ): Promise<ReturnType<typeof request<T, Variables>>> {
     const endpoint = this.buildUrl("/graphql").toString();
-    let requestHeaders: Record<string, string> = {};
-    // The drupal.client has better handling of authentication,
-    // here we just add the token to the request headers.
-    if (withAuth) {
-      const token = await this.getAccessToken();
-      requestHeaders = {
-        authorization: `Bearer ${token.access_token}`,
-      };
-    }
+
+    const token = await this.getAccessToken();
+    const requestHeaders = {
+      authorization: `Bearer ${token.access_token}`,
+    };
+
     // Wrap the request in pRetry to retry failed attempts.
     return await pRetry(
       () => request(endpoint, query, variables, requestHeaders),


### PR DESCRIPTION
Auth is now always required for GraphQL requests.