### PR TITLE
NEX-000: Increase the proxy buffer size to get NextJS login working with ingress-nginx.

### DIFF
--- a/silta/silta-next.yml
+++ b/silta/silta-next.yml
@@ -35,3 +35,8 @@ nginx:
     base-uri 'self';
     connect-src 'self';
     form-action 'self';
+
+ingress:
+  default:
+    extraAnnotations:
+      nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"


### PR DESCRIPTION
<details>
<summary><h3>Fix the proxy buffer size being too small by default:</h3></summary>
<p>
Since we upgraded from traefik to ingress-nginx the NextJS login hasn't been working. This fixes the proxy buffer size, so it works again. 
A Silta wide fix will be coming soon, but with this change we can have it working now. 
</p>
</details>
