### PR TITLE
NEX-101: Improve data fetching and error handling

### DIFF
--- a/next/lib/constants.ts
+++ b/next/lib/constants.ts
@@ -1,0 +1,2 @@
+export const REVALIDATE_SHORT = 10; // 10 seconds
+export const REVALIDATE_LONG = 60 * 10; // 10 minutes

--- a/next/lib/contexts/language-links-context.tsx
+++ b/next/lib/contexts/language-links-context.tsx
@@ -37,10 +37,10 @@ export const getStandardLanguageLinks = () =>
  */
 export function createLanguageLinksForNextOnlyPage(
   path: string,
-  context: GetStaticPropsContext,
+  locales: GetStaticPropsContext["locales"],
 ): LanguageLinks {
   const languageLinks = getStandardLanguageLinks();
-  context.locales.forEach((locale) => {
+  locales.forEach((locale) => {
     languageLinks[locale].path =
       languageLinks[locale].path === "/"
         ? path

--- a/next/lib/drupal/drupal-client.ts
+++ b/next/lib/drupal/drupal-client.ts
@@ -1,13 +1,19 @@
 import { DrupalClient } from "next-drupal";
 import { type TypedDocumentNode } from "@graphql-typed-document-node/core";
 import { request, type RequestDocument, type Variables } from "graphql-request";
-import pRetry, { type Options } from "p-retry";
+import pRetry, { AbortError, type Options } from "p-retry";
 
 import { env } from "@/env";
 
 const RETRY_OPTIONS: Options = {
   retries: env.NODE_ENV === "development" ? 1 : 5,
-  onFailedAttempt: ({ attemptNumber, retriesLeft }) => {
+  onFailedAttempt: ({ attemptNumber, retriesLeft, message }) => {
+    // Don't retry GraphQL errors:
+    if (message.startsWith("GraphQL Error")) {
+      // Throw the relevant part of the error message (e.g. "GraphQL Error (Code: 500)")
+      throw new AbortError(message.slice(0, 25));
+    }
+
     console.log(
       `Fetch ${attemptNumber} failed (${retriesLeft} retries remaining)`,
     );

--- a/next/lib/get-common-page-props.ts
+++ b/next/lib/get-common-page-props.ts
@@ -3,12 +3,18 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
 import { getMenus } from "@/lib/drupal/get-menus";
 
+import siteConfig from "@/site.config";
+
 export type CommonPageProps = Awaited<ReturnType<typeof getCommonPageProps>>;
 
-export async function getCommonPageProps(context: GetStaticPropsContext) {
+export async function getCommonPageProps({
+  locale = siteConfig.defaultLocale,
+}: {
+  locale: GetStaticPropsContext["locale"];
+}) {
   const [translations, menus] = await Promise.all([
-    serverSideTranslations(context.locale),
-    getMenus(context),
+    serverSideTranslations(locale),
+    getMenus({ locale }),
   ]);
 
   return {

--- a/next/pages/404.tsx
+++ b/next/pages/404.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "next-i18next";
 
 import { HeadingPage } from "@/components/heading--page";
 import { Meta } from "@/components/meta";
+import { REVALIDATE_LONG } from "@/lib/constants";
 import {
   CommonPageProps,
   getCommonPageProps,
@@ -32,6 +33,6 @@ export const getStaticProps: GetStaticProps<CommonPageProps> = async ({
     props: {
       ...(await getCommonPageProps({ locale })),
     },
-    revalidate: 60,
+    revalidate: REVALIDATE_LONG,
   };
 };

--- a/next/pages/404.tsx
+++ b/next/pages/404.tsx
@@ -25,12 +25,12 @@ export default function NotFoundPage() {
   );
 }
 
-export const getStaticProps: GetStaticProps<CommonPageProps> = async (
-  context,
-) => {
+export const getStaticProps: GetStaticProps<CommonPageProps> = async ({
+  locale,
+}) => {
   return {
     props: {
-      ...(await getCommonPageProps(context)),
+      ...(await getCommonPageProps({ locale })),
     },
     revalidate: 60,
   };

--- a/next/pages/500.tsx
+++ b/next/pages/500.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "next-i18next";
 
 import { HeadingPage } from "@/components/heading--page";
 import { Meta } from "@/components/meta";
+import { REVALIDATE_LONG } from "@/lib/constants";
 import {
   CommonPageProps,
   getCommonPageProps,
@@ -32,6 +33,6 @@ export const getStaticProps: GetStaticProps<CommonPageProps> = async ({
     props: {
       ...(await getCommonPageProps({ locale })),
     },
-    revalidate: 60,
+    revalidate: REVALIDATE_LONG,
   };
 };

--- a/next/pages/500.tsx
+++ b/next/pages/500.tsx
@@ -25,12 +25,12 @@ export default function NotFoundPage() {
   );
 }
 
-export const getStaticProps: GetStaticProps<CommonPageProps> = async (
-  context,
-) => {
+export const getStaticProps: GetStaticProps<CommonPageProps> = async ({
+  locale,
+}) => {
   return {
     props: {
-      ...(await getCommonPageProps(context)),
+      ...(await getCommonPageProps({ locale })),
     },
     revalidate: 60,
   };

--- a/next/pages/[...slug].tsx
+++ b/next/pages/[...slug].tsx
@@ -3,6 +3,7 @@ import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from "next";
 
 import { Meta } from "@/components/meta";
 import { Node } from "@/components/node";
+import { REVALIDATE_LONG } from "@/lib/constants";
 import {
   createLanguageLinks,
   LanguageLinks,
@@ -126,7 +127,7 @@ export const getStaticProps: GetStaticProps<PageProps> = async ({
   if (!node) {
     return {
       notFound: true,
-      revalidate: 60,
+      revalidate: REVALIDATE_LONG,
     };
   }
 
@@ -164,7 +165,7 @@ export const getStaticProps: GetStaticProps<PageProps> = async ({
     if (!node) {
       return {
         notFound: true,
-        revalidate: 60,
+        revalidate: REVALIDATE_LONG,
       };
     }
   }
@@ -173,7 +174,7 @@ export const getStaticProps: GetStaticProps<PageProps> = async ({
   if (!preview && node.status !== true) {
     return {
       notFound: true,
-      revalidate: 60,
+      revalidate: REVALIDATE_LONG,
     };
   }
 
@@ -193,6 +194,6 @@ export const getStaticProps: GetStaticProps<PageProps> = async ({
       node: node,
       languageLinks,
     },
-    revalidate: 60,
+    revalidate: REVALIDATE_LONG,
   };
 };

--- a/next/pages/[...slug].tsx
+++ b/next/pages/[...slug].tsx
@@ -93,13 +93,15 @@ interface PageProps extends CommonPageProps {
 }
 
 export const getStaticProps: GetStaticProps<PageProps> = async (context) => {
+  const commonPageProps = getCommonPageProps(context);
+
   // Get the path from the context:
   const path = Array.isArray(context.params.slug)
     ? `/${context.params.slug?.join("/")}`
     : context.params.slug;
 
   const variables = {
-    path: path,
+    path,
     langcode: context.locale,
   };
 
@@ -208,7 +210,7 @@ export const getStaticProps: GetStaticProps<PageProps> = async (context) => {
 
   return {
     props: {
-      ...(await getCommonPageProps(context)),
+      ...(await commonPageProps),
       node: nodeEntity,
       languageLinks,
     },

--- a/next/pages/all-articles/[[...page]].tsx
+++ b/next/pages/all-articles/[[...page]].tsx
@@ -59,13 +59,15 @@ export const getStaticPaths: GetStaticPaths = async () => {
   };
 };
 
-export const getStaticProps: GetStaticProps<AllArticlesPageProps> = async (
-  context,
-) => {
-  const commonPageProps = getCommonPageProps(context);
+export const getStaticProps: GetStaticProps<AllArticlesPageProps> = async ({
+  locale,
+  locales,
+  params,
+}) => {
+  const commonPageProps = getCommonPageProps({ locale });
 
   // Get the page parameter:
-  const page = context.params.page;
+  const page = params.page;
   const currentPage = parseInt(Array.isArray(page) ? page[0] : page || "1");
   // This has to match one of the allowed values in the article listing view
   // in Drupal.
@@ -74,7 +76,7 @@ export const getStaticProps: GetStaticProps<AllArticlesPageProps> = async (
   const { totalPages, articles } = await getLatestArticlesItems({
     limit: PAGE_SIZE,
     offset: currentPage ? PAGE_SIZE * (currentPage - 1) : 0,
-    locale: context.locale,
+    locale,
   });
 
   // Create pagination props.
@@ -94,7 +96,7 @@ export const getStaticProps: GetStaticProps<AllArticlesPageProps> = async (
   // Create language links for this page.
   // Note: the links will always point to the first page, because we cannot guarantee that
   // the other pages will exist in all languages.
-  const languageLinks = createLanguageLinksForNextOnlyPage(pageRoot, context);
+  const languageLinks = createLanguageLinksForNextOnlyPage(pageRoot, locales);
 
   return {
     props: {

--- a/next/pages/all-articles/[[...page]].tsx
+++ b/next/pages/all-articles/[[...page]].tsx
@@ -62,6 +62,8 @@ export const getStaticPaths: GetStaticPaths = async () => {
 export const getStaticProps: GetStaticProps<AllArticlesPageProps> = async (
   context,
 ) => {
+  const commonPageProps = getCommonPageProps(context);
+
   // Get the page parameter:
   const page = context.params.page;
   const currentPage = parseInt(Array.isArray(page) ? page[0] : page || "1");
@@ -96,7 +98,7 @@ export const getStaticProps: GetStaticProps<AllArticlesPageProps> = async (
 
   return {
     props: {
-      ...(await getCommonPageProps(context)),
+      ...(await commonPageProps),
       articleTeasers: articles,
       paginationProps: {
         currentPage,

--- a/next/pages/all-articles/[[...page]].tsx
+++ b/next/pages/all-articles/[[...page]].tsx
@@ -7,6 +7,7 @@ import { HeadingPage } from "@/components/heading--page";
 import { LayoutProps } from "@/components/layout";
 import { Meta } from "@/components/meta";
 import { Pagination, PaginationProps } from "@/components/pagination";
+import { REVALIDATE_LONG } from "@/lib/constants";
 import {
   createLanguageLinksForNextOnlyPage,
   LanguageLinks,
@@ -112,6 +113,6 @@ export const getStaticProps: GetStaticProps<AllArticlesPageProps> = async ({
       },
       languageLinks,
     },
-    revalidate: 60,
+    revalidate: REVALIDATE_LONG,
   };
 };

--- a/next/pages/auth/login.tsx
+++ b/next/pages/auth/login.tsx
@@ -133,10 +133,10 @@ export default function LogIn() {
   );
 }
 
-export async function getStaticProps(context: GetStaticPropsContext) {
+export async function getStaticProps({ locale }: GetStaticPropsContext) {
   return {
     props: {
-      ...(await getCommonPageProps(context)),
+      ...(await getCommonPageProps({ locale })),
     },
   };
 }

--- a/next/pages/auth/register.tsx
+++ b/next/pages/auth/register.tsx
@@ -118,10 +118,10 @@ export default function Register() {
   );
 }
 
-export async function getStaticProps(context: GetStaticPropsContext) {
+export async function getStaticProps({ locale }: GetStaticPropsContext) {
   return {
     props: {
-      ...(await getCommonPageProps(context)),
+      ...(await getCommonPageProps({ locale })),
     },
   };
 }

--- a/next/pages/dashboard/index.tsx
+++ b/next/pages/dashboard/index.tsx
@@ -81,11 +81,10 @@ export const getServerSideProps: GetServerSideProps<
   CommonPageProps & {
     submissions: WebformSubmissionsListItem[];
   }
-> = async (context) => {
-  const commonPageProps = getCommonPageProps(context);
+> = async ({ locale, resolvedUrl, req, res }) => {
+  const commonPageProps = getCommonPageProps({ locale });
 
-  const { locale, resolvedUrl } = context;
-  const session = await getServerSession(context.req, context.res, authOptions);
+  const session = await getServerSession(req, res, authOptions);
 
   if (!session) {
     return redirectExpiredSessionToLoginPage(locale, resolvedUrl);

--- a/next/pages/dashboard/index.tsx
+++ b/next/pages/dashboard/index.tsx
@@ -82,6 +82,8 @@ export const getServerSideProps: GetServerSideProps<
     submissions: WebformSubmissionsListItem[];
   }
 > = async (context) => {
+  const commonPageProps = getCommonPageProps(context);
+
   const { locale, resolvedUrl } = context;
   const session = await getServerSession(context.req, context.res, authOptions);
 
@@ -112,7 +114,7 @@ export const getServerSideProps: GetServerSideProps<
 
   return {
     props: {
-      ...(await getCommonPageProps(context)),
+      ...(await commonPageProps),
       submissions,
       session,
     },

--- a/next/pages/dashboard/webforms/[webformName]/[webformSubmissionUuid].tsx
+++ b/next/pages/dashboard/webforms/[webformName]/[webformSubmissionUuid].tsx
@@ -58,6 +58,8 @@ export const getServerSideProps: GetServerSideProps<
     submission: WebformSubmission;
   }
 > = async (context) => {
+  const commonPageProps = getCommonPageProps(context);
+
   const { locale, params, resolvedUrl } = context;
   const session = await getServerSession(context.req, context.res, authOptions);
 
@@ -89,7 +91,7 @@ export const getServerSideProps: GetServerSideProps<
 
   return {
     props: {
-      ...(await getCommonPageProps(context)),
+      ...(await commonPageProps),
       submission,
     },
   };

--- a/next/pages/dashboard/webforms/[webformName]/[webformSubmissionUuid].tsx
+++ b/next/pages/dashboard/webforms/[webformName]/[webformSubmissionUuid].tsx
@@ -57,11 +57,10 @@ export const getServerSideProps: GetServerSideProps<
   CommonPageProps & {
     submission: WebformSubmission;
   }
-> = async (context) => {
-  const commonPageProps = getCommonPageProps(context);
+> = async ({ locale, params, resolvedUrl, req, res }) => {
+  const commonPageProps = getCommonPageProps({ locale });
 
-  const { locale, params, resolvedUrl } = context;
-  const session = await getServerSession(context.req, context.res, authOptions);
+  const session = await getServerSession(req, res, authOptions);
 
   if (!session) {
     return redirectExpiredSessionToLoginPage(locale, resolvedUrl);

--- a/next/pages/index.tsx
+++ b/next/pages/index.tsx
@@ -54,6 +54,8 @@ export default function IndexPage({
 export const getStaticProps: GetStaticProps<HomepageProps> = async (
   context,
 ) => {
+  const commonPageProps = getCommonPageProps(context);
+
   const variables = {
     // This works because it matches the pathauto pattern for the Frontpage content type defined in Drupal:
     path: `frontpage-${context.locale}`,
@@ -100,7 +102,7 @@ export const getStaticProps: GetStaticProps<HomepageProps> = async (
 
   return {
     props: {
-      ...(await getCommonPageProps(context)),
+      ...(await commonPageProps),
       frontpage,
       stickyArticleTeasers: articles,
     },

--- a/next/pages/index.tsx
+++ b/next/pages/index.tsx
@@ -8,6 +8,7 @@ import { LayoutProps } from "@/components/layout";
 import { LogoStrip } from "@/components/logo-strip";
 import { Meta } from "@/components/meta";
 import { Node } from "@/components/node";
+import { REVALIDATE_LONG, REVALIDATE_SHORT } from "@/lib/constants";
 import { drupalClientViewer } from "@/lib/drupal/drupal-client";
 import { getCommonPageProps } from "@/lib/get-common-page-props";
 import type { FragmentArticleTeaserFragment } from "@/lib/gql/graphql";
@@ -76,7 +77,7 @@ export const getStaticProps: GetStaticProps<HomepageProps> = async ({
   if (!frontpage || frontpage.__typename !== "NodeFrontpage") {
     return {
       notFound: true,
-      revalidate: 10,
+      revalidate: REVALIDATE_SHORT,
     };
   }
 
@@ -84,7 +85,7 @@ export const getStaticProps: GetStaticProps<HomepageProps> = async ({
   if (!preview && frontpage.status !== true) {
     return {
       notFound: true,
-      revalidate: 10,
+      revalidate: REVALIDATE_SHORT,
     };
   }
 
@@ -99,6 +100,6 @@ export const getStaticProps: GetStaticProps<HomepageProps> = async ({
       frontpage,
       stickyArticleTeasers: articles,
     },
-    revalidate: 60,
+    revalidate: REVALIDATE_LONG,
   };
 };

--- a/next/pages/index.tsx
+++ b/next/pages/index.tsx
@@ -1,5 +1,6 @@
 import { GetStaticProps, InferGetStaticPropsType } from "next";
 import { useTranslation } from "next-i18next";
+import { AbortError } from "p-retry";
 
 import { ArticleTeasers } from "@/components/article/article-teasers";
 import { ContactList } from "@/components/contact-list";
@@ -8,8 +9,11 @@ import { LayoutProps } from "@/components/layout";
 import { LogoStrip } from "@/components/logo-strip";
 import { Meta } from "@/components/meta";
 import { Node } from "@/components/node";
-import { REVALIDATE_LONG, REVALIDATE_SHORT } from "@/lib/constants";
-import { drupalClientViewer } from "@/lib/drupal/drupal-client";
+import { REVALIDATE_LONG } from "@/lib/constants";
+import {
+  drupalClientPreviewer,
+  drupalClientViewer,
+} from "@/lib/drupal/drupal-client";
 import { getCommonPageProps } from "@/lib/get-common-page-props";
 import type { FragmentArticleTeaserFragment } from "@/lib/gql/graphql";
 import { FragmentMetaTagFragment } from "@/lib/gql/graphql";
@@ -20,6 +24,7 @@ import {
 import { extractEntityFromRouteQueryResult } from "@/lib/graphql/utils";
 import type { FrontpageType } from "@/types/graphql";
 
+import { env } from "@/env";
 import { Divider } from "@/ui/divider";
 
 interface HomepageProps extends LayoutProps {
@@ -58,47 +63,58 @@ export const getStaticProps: GetStaticProps<HomepageProps> = async ({
 }) => {
   const commonPageProps = getCommonPageProps({ locale });
 
+  const drupalClient = preview ? drupalClientPreviewer : drupalClientViewer;
+
+  // This works because it matches the pathauto pattern for the Frontpage content type defined in Drupal:
+  const path = `frontpage-${locale}`;
+
   const [nodeByPathResult, stickyArticleTeasers] = await Promise.all([
-    drupalClientViewer.doGraphQlRequest(GET_ENTITY_AT_DRUPAL_PATH, {
-      // This works because it matches the pathauto pattern for the Frontpage content type defined in Drupal:
-      path: `frontpage-${locale}`,
+    drupalClient.doGraphQlRequest(GET_ENTITY_AT_DRUPAL_PATH, {
+      path,
       langcode: locale,
     }),
-    drupalClientViewer.doGraphQlRequest(LISTING_ARTICLES, {
+    drupalClient.doGraphQlRequest(LISTING_ARTICLES, {
       langcode: locale,
       sticky: true,
       page: 0,
       pageSize: 3,
     }),
-  ]);
+  ]).catch((error: unknown) => {
+    const type =
+      error instanceof AbortError
+        ? "GraphQL"
+        : error instanceof TypeError
+          ? "Network"
+          : "Unknown";
+
+    const moreInfo =
+      type === "GraphQL"
+        ? `Check graphql_compose logs: ${env.NEXT_PUBLIC_DRUPAL_BASE_URL}/admin/reports`
+        : "";
+
+    throw new Error(
+      `${type} Error during GetNodeByPath query with $path: "${path}" and $langcode: "${locale}". ${moreInfo}`,
+    );
+  });
 
   const frontpage = extractEntityFromRouteQueryResult(nodeByPathResult);
 
   if (!frontpage || frontpage.__typename !== "NodeFrontpage") {
-    return {
-      notFound: true,
-      revalidate: REVALIDATE_SHORT,
-    };
+    throw new Error("Frontpage not found for locale " + locale);
   }
 
   // Unless we are in preview, return 404 if the node is set to unpublished:
   if (!preview && frontpage.status !== true) {
-    return {
-      notFound: true,
-      revalidate: REVALIDATE_SHORT,
-    };
+    throw new Error("Frontpage not published for locale " + locale);
   }
-
-  // We cast the results as the ListingArticle type to get type safety:
-  const articles =
-    (stickyArticleTeasers.articlesView
-      ?.results as FragmentArticleTeaserFragment[]) ?? [];
 
   return {
     props: {
       ...(await commonPageProps),
       frontpage,
-      stickyArticleTeasers: articles,
+      stickyArticleTeasers:
+        (stickyArticleTeasers.articlesView
+          ?.results as FragmentArticleTeaserFragment[]) ?? [],
     },
     revalidate: REVALIDATE_LONG,
   };

--- a/next/pages/search.tsx
+++ b/next/pages/search.tsx
@@ -136,12 +136,12 @@ export default function SearchPage() {
   );
 }
 
-export const getStaticProps: GetStaticProps<CommonPageProps> = async (
-  context,
-) => {
+export const getStaticProps: GetStaticProps<CommonPageProps> = async ({
+  locale,
+}) => {
   return {
     props: {
-      ...(await getCommonPageProps(context)),
+      ...(await getCommonPageProps({ locale })),
     },
     revalidate: 60,
   };

--- a/next/pages/search.tsx
+++ b/next/pages/search.tsx
@@ -20,6 +20,7 @@ import { MultiCheckboxFacet } from "@/components/search/search-multicheckbox-fac
 import { Pagination } from "@/components/search/search-pagination";
 import { PagingInfoView } from "@/components/search/search-paging-info";
 import { SearchResult } from "@/components/search/search-result";
+import { REVALIDATE_LONG } from "@/lib/constants";
 import {
   CommonPageProps,
   getCommonPageProps,
@@ -143,6 +144,6 @@ export const getStaticProps: GetStaticProps<CommonPageProps> = async ({
     props: {
       ...(await getCommonPageProps({ locale })),
     },
-    revalidate: 60,
+    revalidate: REVALIDATE_LONG,
   };
 };


### PR DESCRIPTION
## Link to ticket:

https://wunder.atlassian.net/browse/NEX-101

## Link to feature environment:

https://feature-nex-101-data-fetchi4a2.next-drupal-starterkit.dev.wdr.io

## Changes proposed in this PR:

See commits for more specifics, but the main parts of this are:

- Cleanup page data fetching logic in general (getStaticProps, getCommonPageProps etc)
- Encourage faster page generation by kicking off promises as soon as possible (no more waiting until all other page data has been fetched, then `await getCommonPageProps(...)` right at the end)
- Abort the build if a page is 404 during `next build` (pages returned from getStaticPaths should always exist)
- Throw an error if the graphql query for node data is unsuccessful in getStaticProps (and provide a link to CMS logs for further debugging). This means that if there are networking or GraphQL problems, the page will not 404 (current behaviour). Instead, the page won't be updated so the last working version of the page will continue to work. (Still, if a page _should_ 404 as it's been deleted or unpublished, that will still correctly update the page to a 404)

## How to test:

1. Check CI logs build logs and feature environment, should work without errors.
2. After Silta has put the feature environments to sleep, check the site still works by resurrecting the node container but not the Drupal one.
