### PR TITLE
NEX-101: Sitemap.xml improvements

### DIFF
--- a/next/app/sitemap.ts
+++ b/next/app/sitemap.ts
@@ -1,73 +1,153 @@
-import { MetadataRoute } from "next";
+import type { MetadataRoute } from "next";
+import { AbortError } from "p-retry";
 
 import { drupalClientViewer } from "@/lib/drupal/drupal-client";
 import { GET_SITEMAP_NODES } from "@/lib/graphql/queries";
 import {
   addSitemapLanguageVersionsOfFrontpage,
   addSitemapLanguageVersionsOfNode,
+  getLanguagePathFragment,
   makePathAbsolute,
 } from "@/lib/utils";
 
-import siteConfig from "@/site.config";
+import { env } from "@/env";
+import { i18n } from "@/next-i18next.config";
 
-const DEFAULT_SITEMAP_PRIORITY = 0.7;
+const locales = i18n.locales;
+type Locale = (typeof locales)[number];
 
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  // Get all languages from site config:
-  const languages = Object.keys(siteConfig.locales);
-  // Initialize the sitemap:
-  let sitemap = [];
+const SITEMAP_PRIORITY_FRONT = 1;
+const SITEMAP_PRIORITY_LANDING = 0.8;
+const SITEMAP_PRIORITY_DEFAULT = 0.5;
 
-  // For each language, start fetching the nodes for the sitemap:
-  for (const lang of languages) {
-    let page = 0;
-    let totalItems = 0;
-    // Initialize the page size to 0, we will get the actual value from the first request:
-    let pageSize = 0;
+async function getSitemapNodes({
+  locale,
+  page,
+}: {
+  locale: Locale;
+  page: number;
+}) {
+  const response = await drupalClientViewer
+    .doGraphQlRequest(GET_SITEMAP_NODES, {
+      langcode: locale,
+      page,
+    })
+    .catch((error) => {
+      const type =
+        error instanceof AbortError
+          ? "GraphQL"
+          : error instanceof TypeError
+            ? "Network"
+            : "Unknown";
 
-    do {
-      const data = await drupalClientViewer.doGraphQlRequest(
-        GET_SITEMAP_NODES,
-        {
-          page: page,
-          langcode: lang,
-        },
+      const moreInfo =
+        type === "GraphQL"
+          ? `Check graphql_compose logs: ${env.NEXT_PUBLIC_DRUPAL_BASE_URL}/admin/reports`
+          : "";
+
+      throw new Error(
+        `${type} Error during GET_SITEMAP_NODES query for locale "${locale}" at page ${page}. ${moreInfo}`,
       );
+    });
 
-      // Get the total number of items and the page size that is set for the view:
-      if (page === 0) {
-        totalItems = data.sitemapNodes?.pageInfo?.total;
-        pageSize = data.sitemapNodes?.pageInfo?.pageSize;
-      }
-
-      // Prepare the nodes for the sitemap:
-      const nodes = data.sitemapNodes?.results?.map((node) => ({
-        url:
-          // Special case for the frontpage: instead of the node path, use the language path.
-          node.__typename === "NodeFrontpage"
-            ? makePathAbsolute(`/${node.langcode.id}`)
-            : makePathAbsolute(node.path),
-        lastModified: new Date(node.changed.timestamp * 1000),
-        alternates: {
-          languages:
-            node.__typename === "NodeFrontpage"
-              ? addSitemapLanguageVersionsOfFrontpage(node.translations)
-              : addSitemapLanguageVersionsOfNode(node.translations),
-        },
-        priority:
-          node.__typename === "NodeFrontpage" ? 1 : DEFAULT_SITEMAP_PRIORITY,
-      }));
-
-      // Add the nodes to the sitemap:
-      sitemap = [...sitemap, ...nodes];
-      // Increment the page number:
-      page++;
-    } while (page * pageSize < totalItems);
+  if (!response?.sitemapNodes?.results || !response?.sitemapNodes?.pageInfo) {
+    throw new Error(
+      `Sitemap: GET_SITEMAP_NODES returned missing data for locale "${locale}" at page ${page}.`,
+    );
   }
 
-  return sitemap;
+  const { results, pageInfo } = response.sitemapNodes;
+
+  return {
+    results,
+    pageInfo,
+  };
 }
 
-export const revalidate = 3600; // Revalidate the sitemap every hour.
+async function generateSitemap(locale: Locale) {
+  // Fetch the first page of nodes along with the necessary info to fetch the rest:
+  const {
+    results: firstPageNodes,
+    pageInfo: { total, pageSize },
+  } = await getSitemapNodes({
+    locale,
+    page: 0,
+  });
 
-export const fetchCache = "force-no-store";
+  // Create an array containing the remaining pages we need to fetch.
+  // e.g. if pageSize is 100 and total is 350, we still need to fetch pages [1, 2, 3]:
+  const pagesToFetch = Array.from({
+    length: Math.floor(total / pageSize),
+  }).map((_, i) => i + 1);
+
+  // Fetch the remaining pages in parallel:
+  const otherNodes = await Promise.all(
+    pagesToFetch.map((page) =>
+      getSitemapNodes({ locale, page }).then(({ results }) => results),
+    ),
+  );
+
+  // Combine the nodes into a single array:
+  const nodes = [firstPageNodes, ...otherNodes].flat();
+
+  // We can now generate the sitemap for this locale:
+  return nodes
+    .map((node) => {
+      const isFrontpage = node.__typename === "NodeFrontpage";
+      const isLandingpage = isFrontpage
+        ? false
+        : // Matches e.g. "/about-us", but not "/about-us/our-team":
+          node.path.split("/").filter(Boolean).length < 2;
+
+      const url = makePathAbsolute(
+        getLanguagePathFragment(locale) + (isFrontpage ? "" : node.path),
+      );
+
+      const priority =
+        (isFrontpage && SITEMAP_PRIORITY_FRONT) ||
+        (isLandingpage && SITEMAP_PRIORITY_LANDING) ||
+        SITEMAP_PRIORITY_DEFAULT;
+
+      const lastModified = new Date(
+        node.changed.timestamp * 1000,
+      ).toISOString();
+
+      const alternates = {
+        languages:
+          node.__typename === "NodeFrontpage"
+            ? addSitemapLanguageVersionsOfFrontpage(node.translations)
+            : addSitemapLanguageVersionsOfNode(node.translations),
+      };
+
+      return {
+        url,
+        priority,
+        lastModified,
+        alternates,
+      };
+    })
+    .sort((a, b) => {
+      // First sort by priority:
+      const priorityDiff = Number(b.priority) - Number(a.priority);
+      if (priorityDiff) return priorityDiff;
+
+      // Then by last modified date:
+      const lastModifiedDiff = Number(b.lastModified) - Number(a.lastModified);
+      if (lastModifiedDiff) return lastModifiedDiff;
+
+      // Then by url:
+      return a.url.localeCompare(b.url);
+    });
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  // Generate a sitemap for each locale in parallel:
+  const sitemaps: MetadataRoute.Sitemap[] = await Promise.all(
+    locales.map(generateSitemap),
+  );
+
+  // Return the combined sitemap for the site:
+  return sitemaps.flat();
+}
+
+export const revalidate = 3600; // Revalidate the sitemap at most once an hour.

--- a/next/app/sitemap.ts
+++ b/next/app/sitemap.ts
@@ -97,7 +97,10 @@ async function generateSitemap(locale: Locale) {
       const isLandingpage = isFrontpage
         ? false
         : // Matches e.g. "/about-us", but not "/about-us/our-team":
-          node.path.split("/").filter(Boolean).length < 2;
+          node.path
+            .split("/")
+            .filter(Boolean)
+            .filter((pathPart) => pathPart !== locale).length < 2;
 
       const url = makePathAbsolute(
         getLanguagePathFragment(locale) + (isFrontpage ? "" : node.path),

--- a/next/lib/utils.ts
+++ b/next/lib/utils.ts
@@ -1,4 +1,5 @@
 import { env } from "@/env";
+import { defaultLocale } from "@/site.config";
 
 export function formatDate(input: string, locale: string): string {
   const date = new Date(input);
@@ -58,6 +59,14 @@ export const getFileType = (file: string) => {
   }
   return null;
 };
+
+/**
+ * Get the path fragment for the given locale.
+ * @returns "" for the default locale, "/locale" for other locales.
+ */
+export function getLanguagePathFragment(locale?: string) {
+  return !locale || locale === defaultLocale ? "" : `/${locale}`;
+}
 
 export const makePathAbsolute = (path: string) =>
   env.NEXT_PUBLIC_FRONTEND_URL + path;


### PR DESCRIPTION
Similar idea and ticket as https://github.com/wunderio/next-drupal-starterkit/pull/236 but specifically for the sitemap. Decided to do this in a separate PR to keep things a bit more manageable. That one should be merged first, and then the diff for this PR will become smaller without the unrelated changes.

## Link to ticket:

https://wunder.atlassian.net/browse/NEX-101 (ticket is about improving data fetching and error handling in general)

## Link to feature environment:

https://feature-nex-101-sitemap-next.next-drupal-starterkit.dev.wdr.io/sitemap.xml

## Changes proposed in this PR:

- 5b6b2c6247f309c020f82e00e2451103697224eb is the only relevant commit here. Improvements:
- Generate sitemaps for each locale in parallel rather than sequentially
- Fetch each page in parallel rather than sequentially (except for the first page for each locale, as we need that to know how many pages to fetch)
- Improved error messages if GET_SITEMAP_NODES graphql request fails
- Sort resulting sitemap to make it easier to read through and reason about etc

## How to test:

1. Compare the [current sitemap.xml](https://next-drupal-starterkit.dev.wdr.io/sitemap.xml) against the [new sitemap.xml](https://feature-nex-101-sitemap-next.next-drupal-starterkit.dev.wdr.io/sitemap.xml)