### PR TITLE
NEX-165: Add patch to graphql_compose to allow for nodes with unpublished translations

### DIFF
--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -139,6 +139,9 @@
             "drupal/graphql" : {
                 "drupal-graphql#1323: Add check for translation (from Github)": "https://patch-diff.githubusercontent.com/raw/drupal-graphql/graphql/pull/1388.patch"
             },
+            "drupal/graphql_compose" : {
+                "Querying for translations of a node with one or more unpublished translations causes fatal error (d.org issue #3464624)": "./patches/graphql_compose_unpublished_translations.patch"
+            },
             "drupal/core": {
                 "Add support for the experimental recipes functionality (local patch)": "./patches/recipe-10.2.x.patch",
                 "Fix error when enabling the language module via recipe": "https://www.drupal.org/files/issues/2019-11-19/drupal.8.8.x-3002532-20.patch",

--- a/drupal/patches/graphql_compose_unpublished_translations.patch
+++ b/drupal/patches/graphql_compose_unpublished_translations.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Plugin/GraphQLCompose/SchemaType/TranslationType.php b/src/Plugin/GraphQLCompose/SchemaType/TranslationType.php
+index b9db00fe647fbda8b371c9fa4dafa644bb87e0a9..4a6d967c38ed8b82c5723115fef00c1722054636 100644
+--- a/src/Plugin/GraphQLCompose/SchemaType/TranslationType.php
++++ b/src/Plugin/GraphQLCompose/SchemaType/TranslationType.php
+@@ -71,7 +71,7 @@ class TranslationType extends GraphQLComposeSchemaTypeBase {
+           'fields' => function () {
+             return [
+               'translations' => [
+-                'type' => Type::nonNull(Type::listOf(Type::nonNull(static::type($this->getPluginId())))),
++                'type' => Type::nonNull(Type::listOf(static::type($this->getPluginId()))),
+                 'description' => (string) $this->t('Available translations for content.'),
+               ],
+             ];


### PR DESCRIPTION
Applies patch found at https://www.drupal.org/project/graphql_compose/issues/3464624