### PR TITLE
NEX-172: Fix preview of previous revisions of nodes

### DIFF
--- a/next/pages/[...slug].tsx
+++ b/next/pages/[...slug].tsx
@@ -191,8 +191,8 @@ export const getStaticProps: GetStaticProps<PageProps> = async ({
     typeof previewData.resourceVersion === "string" &&
     previewData.resourceVersion !== "rel:latest-version"
   ) {
-    const [nodeId, revisionId] = previewData.resourceVersion.split(":");
-    const path = `/node/${nodeId}/revisions/${revisionId}/view`;
+    const [_, revisionId] = previewData.resourceVersion.split(":");
+    const path = `/node/${node.id}/revisions/${revisionId}/view`;
     const revisionRoutedata = await drupalClient.doGraphQlRequest(
       GET_ENTITY_AT_DRUPAL_PATH,
       { path, langcode: locale },


### PR DESCRIPTION
## Link to ticket:

https://wunder.atlassian.net/browse/NEX-172 

## Changes proposed in this PR:
We were not correctly passing the node id when doing the graphql query to get the entity at a certain revision. This PR fixes that.


## How to test:

1. edit a piece of content
2. a revision is created
3. click on the "revisions" tab
4. click on the link of the previous revision
5. the content is shown at that revision
