### PR TITLE
NEX-173: Redirect to current page after exiting preview

### DIFF
--- a/next/components/preview-banner.tsx
+++ b/next/components/preview-banner.tsx
@@ -14,15 +14,23 @@ export function useIsPreviewBannerVisible() {
 }
 
 export function PreviewBanner({ isVisible }: { isVisible: boolean }) {
+  const router = useRouter();
+
   if (!isVisible) {
     return null;
   }
 
+  // If the current locale is the default locale, we don't need to include the locale in the callback URL
+  const callbackUrl = `${router.locale === router.defaultLocale ? "" : `/${router.locale}`}${router.asPath}`;
+
   return (
-    <div className="absolute top-0 z-50 w-full bg-steelgray px-2 py-2 text-center text-mischka">
+    <div className="absolute top-0 z-50 w-full px-2 py-2 text-center bg-steelgray text-mischka">
       This page is a preview.{" "}
       {/* eslint-disable @next/next/no-html-link-for-pages */}
-      <a href="/api/exit-preview" className="underline">
+      <a
+        href={`/api/exit-preview?callbackUrl=${encodeURIComponent(callbackUrl)}`}
+        className="underline"
+      >
         Click here
       </a>{" "}
       to exit preview mode.

--- a/next/pages/api/exit-preview.ts
+++ b/next/pages/api/exit-preview.ts
@@ -1,7 +1,12 @@
-import { NextApiResponse } from "next";
+import { NextApiRequest, NextApiResponse } from "next";
 
-export default function exit(_, response: NextApiResponse) {
+export default function exit(
+  request: NextApiRequest,
+  response: NextApiResponse,
+) {
+  // Get the callback URL from the query parameters
+  const { callbackUrl } = request.query;
   response.clearPreviewData();
-  response.writeHead(307, { Location: "/" });
-  response.end();
+  // Redirect to the callback URL or the homepage if the callback URL is not provided
+  response.redirect(307, (callbackUrl as string) ?? "/");
 }


### PR DESCRIPTION
## Link to ticket:

[NEX-173](https://wunder.atlassian.net/browse/NEX-173)

## Link to feature environment:

[Next.js](https://nex-173-next.next-drupal-starterkit.dev.wdr.io/) `silta/demo`
[Drupal](https://nex-173.next-drupal-starterkit.dev.wdr.io/) `admin/admin`

## Changes proposed in this PR:

### What?
Keep the developer or content editor on the current page after exiting preview mode.

### How?
Added a callback URL to the exit link in preview-banner.tsx. This callback is passed to /api/exit-preview.tsx to redirect the user back to the same page after exiting preview mode.

### Why?
To improve the user experience by preventing unnecessary redirects when exiting preview mode. This ensures that developers and content editors remain on the page they were previewing, allowing them to continue their workflow without disruption.

## How to test:
1. Ensure both the frontend and backend environments are running.
2. Edit some content in Drupal and save it.
3. Click the "View" button in Drupal’s previewer to open the frontend.
4. Exit the preview mode and confirm that you remain on the same page.

## Best practices:

<details>
<summary><h3>Accessibility:</h3></summary>
<p>
This project must support WCAG accessibility level AA <em>(edit this according to the requirements of your project)</em>. To ensure this standard is met, remember to:

- Perform automated checks using a tool such as Wave or SiteImprove.
- Test keyboard navigation: are all parts of the UI navigable using only the keyboard? Is the tab order logical? Can popups, menus etc be dismissed with the escape key?
- Test responsiveness, scaling and text reflow.
- Make sure no accessibility issues exist on either desktop or mobile views.
- If you have time, test with a screen reader such as VoiceOver (macOS), NVDA (Windows), or Orca (Linux).

Use the [Accessibility Testing Cheat Sheet](https://intra.wunder.io/info/accessibility-group/accessibility-testing-cheat-sheet) for information on how to run these tests.

</p>
</details>


[NEX-173]: https://wunder.atlassian.net/browse/NEX-173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ