### PR TITLE
Tell Lando node service to use the openssl CA

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -151,6 +151,8 @@ services:
         NEXTAUTH_URL: https://frontend.lndo.site
         REDIS_HOST: redis
         REDIS_PASS: "mypassword"
+        # Needed in lando > 3.22 to use openssl CA for node.
+        NODE_OPTIONS: --use-openssl-ca
     build:
       - "cd next && npm ci"
     scanner: false
@@ -245,4 +247,4 @@ env_file:
   - .lando/.env
 
 # Tested with Lando version
-version: v3.21
+version: v3.22


### PR DESCRIPTION
* This has become necessary in newer versions of lando to be able to access the drupal service from within lando using https.

(See https://github.com/lando/core/issues/229 )