### PR TITLE
Add the NODE_EXTRA_CA_CERTS env var to the node service

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -151,8 +151,8 @@ services:
         NEXTAUTH_URL: https://frontend.lndo.site
         REDIS_HOST: redis
         REDIS_PASS: "mypassword"
-        # Needed in lando > 3.22 to use openssl CA for node.
-        NODE_OPTIONS: --use-openssl-ca
+        # We instruct node to use the Lando CA certificate for HTTPS connections:
+        NODE_EXTRA_CA_CERTS: /lando/certs/LandoCA.crt
     build:
       - "cd next && npm ci"
     scanner: false


### PR DESCRIPTION
Similar idea as https://github.com/wunderio/next-drupal-starterkit/pull/254 , but without using the NODE_OPTIONS env var.

This feels like we are using the right env var for the job.

* This has become necessary in newer versions of lando to be able to access the drupal service from within lando using https.