### PR TITLE
NEX-174: Do not return anything from the api preview route

### DIFF
--- a/next/pages/api/preview.ts
+++ b/next/pages/api/preview.ts
@@ -6,5 +6,5 @@ export default async function handler(
   request: NextApiRequest,
   response: NextApiResponse,
 ) {
-  return await drupalClientPreviewer.preview(request, response);
+  await drupalClientPreviewer.preview(request, response);
 }


### PR DESCRIPTION
* this fixes the notice: API handler should not return a value, received object.

To test: 

1. start the server in dev mode
1. open a node in drupal's node view
2. observe that the notice "API handler should not return a value, received object." is not displayed anymore in the console

(This was fixed in another project, I am porting the fix here)
