### PR TITLE
NEX-175: Add the possibility of running npx commands in lando

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -26,6 +26,10 @@ tooling:
     service: node
     dir: /app/next
 
+  npx:
+    command: "npx"
+    service: node
+
   # This command will stop (kill) any running node operations
   # in the node container in lando. You can use it instead of the
   # usual ctrl-c keyboard combination.
@@ -154,6 +158,8 @@ services:
         # We instruct node to use the Lando CA certificate for HTTPS connections:
         NODE_EXTRA_CA_CERTS: /lando/certs/LandoCA.crt
     build:
+      # This is needed to be able to run lando npx commands:
+      - "mkdir -p /var/www/.npm-global/lib"
       - "cd next && npm ci"
     scanner: false
 

--- a/.lando.yml
+++ b/.lando.yml
@@ -27,8 +27,8 @@ tooling:
     dir: /app/next
 
   npx:
-    command: "npx"
     service: node
+    dir: /app/next
 
   # This command will stop (kill) any running node operations
   # in the node container in lando. You can use it instead of the


### PR DESCRIPTION
This branch adds the npx command to lando.

To test:

1. switch to this branch
2. if you were working with an app router branch before (it will delete untracked file, so be careful?) `git clean -d -f`
3. `./setup-lando.sh -c`
4. stop the server with control-c
5. cd next (the npx command will be executed in the directory you are in
6. for example: `lando npx shadcn@latest add badge`