### PR TITLE
Revert our workaround to fix lando CA node cert issues

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -155,8 +155,6 @@ services:
         NEXTAUTH_URL: https://frontend.lndo.site
         REDIS_HOST: redis
         REDIS_PASS: "mypassword"
-        # Needed in lando > 3.22 to use openssl CA for node.
-        NODE_OPTIONS: --use-openssl-ca
     build:
       # This is needed to be able to run lando npx commands:
       - "mkdir -p /var/www/.npm-global/lib"
@@ -253,4 +251,4 @@ env_file:
   - .lando/.env
 
 # Tested with Lando version
-version: v3.22
+version: v3.21

--- a/.lando.yml
+++ b/.lando.yml
@@ -251,4 +251,4 @@ env_file:
   - .lando/.env
 
 # Tested with Lando version
-version: v3.21
+version: v3.22.3

--- a/.lando.yml
+++ b/.lando.yml
@@ -155,8 +155,8 @@ services:
         NEXTAUTH_URL: https://frontend.lndo.site
         REDIS_HOST: redis
         REDIS_PASS: "mypassword"
-        # We instruct node to use the Lando CA certificate for HTTPS connections:
-        NODE_EXTRA_CA_CERTS: /lando/certs/LandoCA.crt
+        # Needed in lando > 3.22 to use openssl CA for node.
+        NODE_OPTIONS: --use-openssl-ca
     build:
       # This is needed to be able to run lando npx commands:
       - "mkdir -p /var/www/.npm-global/lib"


### PR DESCRIPTION
Reverts wunderio/next-drupal-starterkit#255 and wunderio/next-drupal-starterkit#254

Lando has now included similar changes: https://github.com/lando/node/commit/50b0fa7aa33bfe0df8eb1f91296a15c2a6492ee8 

So we can revert these changes. Make sure you are using the latest version of lando.