### PR TITLE
Add swrDelta config option for CDNs (app router branch)

### DIFF
--- a/next/next.config.js
+++ b/next/next.config.js
@@ -38,6 +38,9 @@ const nextConfig = {
     });
     return config;
   },
+  experimental: {
+    swrDelta: 31536000, // 1 year
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
This ensures CDNs can serve stale page contents for one year. See links for more info:
https://www.flightcontrol.dev/blog/secret-knowledge-to-self-host-nextjs#isr--stale-while-revalidate https://focusreactive.com/configure-cdn-caching-for-self-hosted-next-js-websites/#stale-while-revalidate