### PR TITLE
NEX-84: Support forward revisions when displaying a revision in the node page in drupal

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,13 @@ ddev describe
 
 We try to add to the template what we think are the most commonly requested features in website projects. Most of these are based on the features provided by [Next.js for Drupal](https://next-drupal.org/), but we have paid special attention to making these work in a multilanguage setup.
 
-### Preview mode
+### Draft mode
 
-The template is set up to allow editors to use [Draft mode](https://nextjs.org/docs/app/building-your-application/configuring/draft-mode). Visit the node page on the Drupal side while the frontend is running to see a preview of the page.
+The template is set up to allow editors to use [Draft mode](https://nextjs.org/docs/app/building-your-application/configuring/draft-mode). Visit the node page on the Drupal side while the frontend is running to see a preview of the page. This works also for unpublished content, and for draft revisions.
+
+### Drupal preview
+
+You can preview changes to a piece of content, or even a completely new piece of content before saving it the first time. Use the usual preview button in the Drupal backend to see the changes in the frontend.
 
 ### On-demand revalidation
 

--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -143,7 +143,8 @@
                 "drupal-graphql#1323: Add check for translation (from Github)": "https://patch-diff.githubusercontent.com/raw/drupal-graphql/graphql/pull/1388.patch"
             },
             "drupal/graphql_compose" : {
-                "entity_url producer in preview returns error #3503977": "patches/graphl_compose_entity_url_in_preview_returns_error.patch"
+                "entity_url producer in preview returns error #3503977": "patches/graphl_compose_entity_url_in_preview_returns_error.patch",
+                "Add revision parameter to route query #3462517": "https://git.drupalcode.org/project/graphql_compose/-/commit/accdf36065419fdc9e0e2c342fef556a11ea8437.patch"
             },
             "drupal/core": {
                 "Fix error when enabling the language module via recipe": "https://www.drupal.org/files/issues/2019-11-19/drupal.8.8.x-3002532-20.patch"

--- a/drupal/recipes/wunder_pages/config/workflows.workflow.moderation.yml
+++ b/drupal/recipes/wunder_pages/config/workflows.workflow.moderation.yml
@@ -1,0 +1,41 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+  module:
+    - content_moderation
+id: moderation
+label: Moderation
+type: content_moderation
+type_settings:
+  states:
+    draft:
+      label: Draft
+      weight: 0
+      published: false
+      default_revision: false
+    published:
+      label: Published
+      weight: 1
+      published: true
+      default_revision: true
+  transitions:
+    create_new_draft:
+      label: 'Create New Draft'
+      from:
+        - draft
+        - published
+      to: draft
+      weight: 0
+    publish:
+      label: Publish
+      from:
+        - draft
+        - published
+      to: published
+      weight: 1
+  entity_types:
+    node:
+      - page
+  default_moderation_state: draft

--- a/drupal/recipes/wunder_pages/recipe.yml
+++ b/drupal/recipes/wunder_pages/recipe.yml
@@ -11,10 +11,14 @@ install:
   - node
   - text
   - pathauto
+  - workflows
+  - content_moderation
 config:
   import:
     paragraphs: '*'
     pathauto: '*'
+    workflows: '*'
+    content_moderation: '*'
   actions:
     user.role.wunder_content_editor:
       ensure_exists:

--- a/drupal/web/modules/custom/wunder_democontent/migrations/nodes_pages.yml
+++ b/drupal/web/modules/custom/wunder_democontent/migrations/nodes_pages.yml
@@ -8,6 +8,7 @@ source:
   constants:
     status: 1
     uid: 1
+    moderation_state: published
 process:
   # We are interested here only in nodes that are not translations:
   skipped:
@@ -23,6 +24,7 @@ process:
     default_value: page
   title: Title
   status: constants/status
+  moderation_state: constants/moderation_state
   uid: constants/uid
   langcode: Langcode
   field_excerpt: Excerpt

--- a/drupal/web/modules/custom/wunder_democontent/migrations/nodes_pages_translations.yml
+++ b/drupal/web/modules/custom/wunder_democontent/migrations/nodes_pages_translations.yml
@@ -8,6 +8,7 @@ source:
   constants:
     status: 1
     uid: 1
+    moderation_state: published
 process:
   # We are interested here only in nodes that are translations:
   skipped:
@@ -27,6 +28,7 @@ process:
   title: Title
   field_excerpt: Excerpt
   status: constants/status
+  moderation_state: constants/moderation_state
   uid: constants/uid
   langcode: Langcode
 

--- a/next/src/app/[locale]/(dynamic)/[...slug]/page.tsx
+++ b/next/src/app/[locale]/(dynamic)/[...slug]/page.tsx
@@ -95,12 +95,13 @@ export default async function NodePage({
       typeof draftData.resourceVersion === "string" &&
       draftData.resourceVersion !== "rel:latest-version"
     ) {
-      const revisionId = draftData.resourceVersion.split(":").slice(1);
-      const revisionPath = `/node/${node.id}/revisions/${revisionId}/view`;
+      const [_, revision] = draftData.resourceVersion.split(":");
+      const revisionPath = `/node/${node.id}`;
       const revisionData = await getNodeByPathQuery(
         revisionPath,
         locale,
-        isDraftMode,
+        true,
+        revision,
       );
 
       // Instead of the entity at the current revision, we want now to

--- a/next/src/lib/drupal/get-node.ts
+++ b/next/src/lib/drupal/get-node.ts
@@ -16,6 +16,7 @@ import { env } from "@/env";
  *
  * @param path The path of the node.
  * @param locale The locale of the node.
+ * @param revision The revision of the node.
  * @param isDraftMode If true, fetches the draft version of the node.
  * @returns The fetched node data or null if not found.
  */
@@ -23,11 +24,13 @@ export async function fetchNodeByPathQuery(
   path: string,
   locale: string,
   isDraftMode: boolean,
+  revision: string = null,
 ) {
   const drupalClient = isDraftMode ? drupalClientPreviewer : drupalClientViewer;
   return await drupalClient.doGraphQlRequest(GET_ENTITY_AT_DRUPAL_PATH, {
     path,
     langcode: locale,
+    revision,
   });
 }
 
@@ -40,6 +43,7 @@ const cachedFetchNodeByPathQuery = neshCache(cache(fetchNodeByPathQuery));
  * @param path The Drupal path of the node.
  * @param locale The language code for the locale of the node.
  * @param isDraftMode Optional. Defaults to false. If true, fetches the draft version of the node.
+ * @param revision Optional. The revision of the node.
  * @returns An object containing the node data or an error message.
  *
  * @example
@@ -47,11 +51,15 @@ const cachedFetchNodeByPathQuery = neshCache(cache(fetchNodeByPathQuery));
  *
  * // With draft mode enabled:
  * const { data, error } = await getNodeByPathQuery('/about-us', 'en', true);
+ *
+ * // With draft mode enabled and a specific revision:
+ * const { data, error } = await getNodeByPathQuery('/about-us', 'en', true, 'working_copy');
  */
 export async function getNodeByPathQuery(
   path: string,
   locale: string,
   isDraftMode: boolean = false,
+  revision: string = null,
 ) {
   try {
     return await cachedFetchNodeByPathQuery(
@@ -59,6 +67,7 @@ export async function getNodeByPathQuery(
       path,
       locale,
       isDraftMode,
+      revision,
     );
   } catch (error) {
     const type =

--- a/next/src/lib/graphql/queries.ts
+++ b/next/src/lib/graphql/queries.ts
@@ -4,8 +4,8 @@ import { graphql } from "@/lib/gql";
  * Given a path, this query will return the node, or a redirect.
  */
 export const GET_ENTITY_AT_DRUPAL_PATH = graphql(`
-  query GetNodeByPath($path: String!, $langcode: String!) {
-    route(path: $path, langcode: $langcode) {
+  query GetNodeByPath($path: String!, $langcode: String!, $revision: ID) {
+    route(path: $path, langcode: $langcode, revision: $revision) {
       __typename
       ... on RouteInternal {
         __typename


### PR DESCRIPTION
This PR adds:

1. enabling of the workflows and content moderation modules
2. add patch at https://www.drupal.org/project/graphql_compose/issues/3462517 for graphl_compose to add the possibility of adding the revision to a route query
3. adapting the frontend code to pass the version in the expected way

## How it looks


https://github.com/user-attachments/assets/ea680c08-20b0-4631-b7ea-4213279b0bb8


## How to test

1. `./setup-lando.sh -c`
2. log into the backend, edit a "page", create a draft revision, preview it at node/id
3. create a new page, save it in as a draft, you should be able to see it at node/id


