### PR TITLE
NEX-185: Update to next-drupal 2.0

### DIFF
--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -33,7 +33,7 @@
         "drupal/migrate_source_csv": "^3.5",
         "drupal/migrate_tools": "^6.0",
         "drupal/monolog": "^3.0@beta",
-        "drupal/next": "^2.0@beta",
+        "drupal/next": "^2.0",
         "drupal/paragraphs": "^1.18",
         "drupal/pathauto": "^1.13",
         "drupal/redirect": "^1.10",

--- a/drupal/composer.lock
+++ b/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0a99dde3df1cc1250e28623311e195de",
+    "content-hash": "d8a975009a3d0ae409a295526315004e",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2704,17 +2704,17 @@
         },
         {
             "name": "drupal/next",
-            "version": "2.0.0-beta1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/next.git",
-                "reference": "2.0.0-beta1"
+                "reference": "2.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/next-2.0.0-beta1.zip",
-                "reference": "2.0.0-beta1",
-                "shasum": "f60775bcdb4333dc28db85b2127abf14c97540b6"
+                "url": "https://ftp.drupal.org/files/projects/next-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "1a7b07042d72fbfafd105c639b2bff062311a099"
             },
             "require": {
                 "drupal/core": "^10 || ^11",
@@ -2735,11 +2735,11 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.0-beta1",
-                    "datestamp": "1728074311",
+                    "version": "2.0.0",
+                    "datestamp": "1739303969",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Beta releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 }
             },
@@ -2751,6 +2751,10 @@
                 {
                     "name": "shadcn",
                     "homepage": "https://www.chapterthree.com"
+                },
+                {
+                    "name": "brianperry",
+                    "homepage": "https://www.drupal.org/user/2304500"
                 },
                 {
                     "name": "johnalbin",
@@ -17470,7 +17474,6 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "drupal/monolog": 10,
-        "drupal/next": 10,
         "drupal/simplei": 10
     },
     "prefer-stable": true,

--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -34,7 +34,7 @@
         "lucide-react": "^0.469.0",
         "next": "^14.2.22",
         "next-auth": "^5.0.0-beta.25",
-        "next-drupal": "^2.0.0-beta.1",
+        "next-drupal": "^2.0.0",
         "next-intl": "^3.26.3",
         "next-themes": "^0.4.4",
         "p-retry": "^6.2.1",
@@ -16185,17 +16185,17 @@
       }
     },
     "node_modules/next-drupal": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/next-drupal/-/next-drupal-2.0.0-beta.1.tgz",
-      "integrity": "sha512-OwPUtkCWExRbpydbNtdKSGjpSt8RYlp+jhj4hgTkEj9zZcwVPKBqdGn82rNM13KbwiY1RVAJypsRQKwHAwXK7A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/next-drupal/-/next-drupal-2.0.0.tgz",
+      "integrity": "sha512-cgkfdSe2iepaiJkG4586SyCrUoXNsCfj9r1CcChidDZN7iDPLSKIIq8i63Yf0lPzLz+amwVW9lhWwrErOy8OIA==",
       "license": "MIT",
       "dependencies": {
         "jsona": "^1.12.1",
-        "next": "^13.4 || ^14",
+        "next": "^14.2.21 || ^15.1.2",
         "node-cache": "^5.1.2",
-        "qs": "^6.12.1",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "qs": "^6.13.1",
+        "react": "^18.2 || ^19.0",
+        "react-dom": "^18.2 || ^19.0"
       }
     },
     "node_modules/next-intl": {

--- a/next/package.json
+++ b/next/package.json
@@ -45,7 +45,7 @@
     "lucide-react": "^0.469.0",
     "next": "^14.2.22",
     "next-auth": "^5.0.0-beta.25",
-    "next-drupal": "^2.0.0-beta.1",
+    "next-drupal": "^2.0.0",
     "next-intl": "^3.26.3",
     "next-themes": "^0.4.4",
     "p-retry": "^6.2.1",
@@ -100,10 +100,5 @@
     "tailwindcss": "^3.4.17",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.2"
-  },
-  "overrides": {
-    "next-drupal": {
-      "next": "$next"
-    }
   }
 }

--- a/next/src/app/[locale]/(dynamic)/[...slug]/page.tsx
+++ b/next/src/app/[locale]/(dynamic)/[...slug]/page.tsx
@@ -86,7 +86,7 @@ export default async function NodePage({
   // In this case, the draftData will contain the resourceVersion property,
   // which we can use to fetch the correct revision:
   if (isDraftMode) {
-    const draftData = getDraftData();
+    const draftData = await getDraftData();
 
     if (
       draftData &&

--- a/next/src/app/api/disable-draft/route.ts
+++ b/next/src/app/api/disable-draft/route.ts
@@ -8,6 +8,6 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const callbackPath = searchParams.get("callbackPath");
 
-  disableDraftMode();
+  await disableDraftMode();
   redirect(callbackPath ?? "/");
 }


### PR DESCRIPTION
## Changes proposed in this PR:

Next-drupal 2.0 is out! https://next-drupal.org/blog/next-drupal-2-0

This pr updates the starterkit to it.

## How to test:

1. ./lando-setup.sh -c 
2. create pages, preview pages, log in, etc