### PR TITLE
NEX-187: Fix issues with latest version tab and translated entities

### DIFF
--- a/drupal/web/modules/custom/wunder_next/wunder_next.module
+++ b/drupal/web/modules/custom/wunder_next/wunder_next.module
@@ -226,16 +226,11 @@ function wunder_next_page_attachments_alter(array &$attachments) {
  */
 function wunder_next_next_site_preview_alter(array &$preview, array &$context) {
 
-  // For our use case, we always want to show the preview in the active
-  // language, if the entity has a translation for it.
-  $active_language = \Drupal::languageManager()->getCurrentLanguage();
-
-  if ($context['entity']->hasTranslation($active_language->getId())) {
-    // If the entity has a translation in the active language, we want to
-    // use the translation for the preview.
-    $context['entity'] = $context['entity']->getTranslation($active_language->getId());
-    // Rebuild the preview with the new entity.
-    $preview = $context['plugin']->render($context['entity'], $context['sites']);
-  }
+  /** @var \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository */
+  $entity_repository = \Drupal::service('entity.repository');
+  // Make sure we use the translated version of the entity, if available:
+  $context['entity'] = $entity_repository->getTranslationFromContext($context['entity']);
+  // Rebuild the preview:
+  $preview = $context['plugin']->render($context['entity'], $context['sites']);
 
 }

--- a/drupal/web/modules/custom/wunder_next/wunder_next.module
+++ b/drupal/web/modules/custom/wunder_next/wunder_next.module
@@ -220,3 +220,22 @@ function wunder_next_page_attachments_alter(array &$attachments) {
     'noindex',
   ];
 }
+
+/**
+ * Implements hook_next_site_preview_alter().
+ */
+function wunder_next_next_site_preview_alter(array &$preview, array &$context) {
+
+  // For our use case, we always want to show the preview in the active
+  // language, if the entity has a translation for it.
+  $active_language = \Drupal::languageManager()->getCurrentLanguage();
+
+  if ($context['entity']->hasTranslation($active_language->getId())) {
+    // If the entity has a translation in the active language, we want to
+    // use the translation for the preview.
+    $context['entity'] = $context['entity']->getTranslation($active_language->getId());
+    // Rebuild the preview with the new entity.
+    $preview = $context['plugin']->render($context['entity'], $context['sites']);
+  }
+
+}


### PR DESCRIPTION
After merging #276 , we noticed that in multilingual content, the "latest revision" tab would always show the node in the default language, even if a translation existed.

## The issue

https://github.com/user-attachments/assets/999083b7-3481-496c-8776-7c55f3ddf975


## How we fix it

In this PR we fix this issue by leveraging the `_next_next_site_preview_alter` hook, checking if the entity has a translation for the active language of the site, and switching to the translation if so.