### PR TITLE
Remove instructions to downgrade the graphql.vscode-graphql vscode extension

### DIFF
--- a/next/.vscode/extensions.json
+++ b/next/.vscode/extensions.json
@@ -4,7 +4,7 @@
     "esbenp.prettier-vscode",
     "stylelint.vscode-stylelint",
     "bradlc.vscode-tailwindcss",
-    "graphql.vscode-graphql", // note: v0.9.3 is recommended for now, 0.11.0 has a bug: https://github.com/graphql/graphiql/issues/3620
+    "graphql.vscode-graphql",
     "graphql.vscode-graphql-syntax"
   ]
 }


### PR DESCRIPTION
Versions of the [GraphQL: Language Feature Support](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) > 0.9.4 < 0.13 produced an error when used with graphql codegen.

The newly released 0.13.2 version that contains https://github.com/graphql/graphiql/pull/3861 now fixes the problem, so we can remove our comment from the `extensions.json` file. 🥳  